### PR TITLE
feat: 분실물 찾기의 퀴즈  및 서약 기능 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'io.rest-assured:rest-assured:5.4.0'
 
 	implementation 'org.hibernate.orm:hibernate-spatial'
 	implementation 'org.locationtech.jts:jts-core'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,12 @@ services:
     container_name: mysql-server
     volumes:
       - ./mysql_data:/var/lib/mysql
+
+  mysql-test:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: test135
+      MYSQL_DATABASE: zupzup_test_db
+    ports:
+      - 3307:3306
+    container_name: mysql-test

--- a/src/main/java/com/greedy/zupzup/DataLoader.java
+++ b/src/main/java/com/greedy/zupzup/DataLoader.java
@@ -1,10 +1,19 @@
 package com.greedy.zupzup;
 
-
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.domain.Feature;
 import com.greedy.zupzup.category.domain.FeatureOption;
 import com.greedy.zupzup.category.repository.CategoryRepository;
+import com.greedy.zupzup.lostitem.domain.LostItem;
+import com.greedy.zupzup.lostitem.domain.LostItemFeature;
+import com.greedy.zupzup.lostitem.domain.LostItemImage;
+import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemRepository;
+import com.greedy.zupzup.member.Member;
+import com.greedy.zupzup.member.Provider;
+import com.greedy.zupzup.member.Role;
+import com.greedy.zupzup.member.repository.MemberRepository;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import com.greedy.zupzup.schoolarea.repository.SchoolAreaRepository;
 import jakarta.transaction.Transactional;
@@ -28,25 +37,59 @@ import java.util.List;
 public class DataLoader implements CommandLineRunner {
 
     private final SchoolAreaRepository schoolAreaRepository;
+    private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final LostItemRepository lostItemRepository;
+    private final LostItemFeatureRepository lostItemFeatureRepository;
+    private final LostItemImageRepository lostItemImageRepository;
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
     @Override
     @Transactional
     public void run(String... args) throws Exception {
-
-        // ================= 기존 구역 정보 초기화 =================
+        log.info("========== 개발용 임시 데이터 초기화 시작 ==========");
         initSchoolAreaData();
-        // ================= 카테고리 및 관련 정보 초기화 =================
         initCategoryData();
+        initMemberData();
+        initLostItemData();
+        log.info("========== 개발용 임시 데이터 초기화 완료 ==========");
+    }
+
+    private void initSchoolAreaData() {
+        log.info("구역 정보를 초기화합니다.");
+        if (schoolAreaRepository.count() == 0) {
+            Polygon playground = geometryFactory.createPolygon(
+                    new Coordinate[]{new Coordinate(127.0752831, 37.5510817), new Coordinate(127.0742638, 37.5502523),
+                            new Coordinate(127.0749505, 37.5498356), new Coordinate(127.0759912, 37.5507372),
+                            new Coordinate(127.0752831, 37.5510817)});
+            SchoolArea playgroundZone = SchoolArea.builder().areaName("세종대학교 운동장").area(playground).build();
+
+            Polygon sideRoad = geometryFactory.createPolygon(
+                    new Coordinate[]{new Coordinate(127.0738508, 37.5506351), new Coordinate(127.0742638, 37.5502523),
+                            new Coordinate(127.075326, 37.5511285), new Coordinate(127.0747198, 37.5516133),
+                            new Coordinate(127.0740868, 37.5510902), new Coordinate(127.0739902, 37.5510051),
+                            new Coordinate(127.0741565, 37.5508605), new Coordinate(127.0738508, 37.5506351)});
+            SchoolArea sideRoadZone = SchoolArea.builder().areaName("세종대학교 운동장 옆 길").area(sideRoad).build();
+
+            Polygon aiCenter = geometryFactory.createPolygon(
+                    new Coordinate[]{new Coordinate(127.0754923, 37.551137), new Coordinate(127.0757605, 37.5508988),
+                            new Coordinate(127.076018, 37.5510647), new Coordinate(127.0757015, 37.5512986),
+                            new Coordinate(127.0754923, 37.551137)});
+            SchoolArea aiCenterZone = SchoolArea.builder().areaName("세종대학교 AI 센터").area(aiCenter).build();
+
+            schoolAreaRepository.saveAll(Arrays.asList(playgroundZone, sideRoadZone, aiCenterZone));
+            log.info("임시 구역 정보 초기화 완료!");
+        } else {
+            log.info("구역 정보가 이미 존재하여 초기화를 건너뜁니다.");
+        }
     }
 
     private void initCategoryData() {
-        log.info("카테고리 및 관련 특성 정보를 초기화합니다.");
+        log.info("카테고리 정보를 초기화합니다.");
         if (categoryRepository.count() == 0) {
-            // --- 1. 전자기기 카테고리 ---
-            Category electronics = Category.builder().name("전자기기").iconUrl("https://cdn-icons-png.flaticon.com/128/519/519184.png").build();
-
+            // --- 1. 핸드폰(전자기기) 카테고리 ---
+            Category electronics = Category.builder().name("핸드폰")
+                    .iconUrl("https://cdn-icons-png.flaticon.com/128/519/519184.png").build();
             Feature brand = Feature.builder().name("브랜드").quizQuestion("어떤 브랜드의 제품인가요?").category(electronics).build();
             brand.getOptions().addAll(List.of(
                     FeatureOption.builder().optionValue("삼성").feature(brand).build(),
@@ -54,7 +97,6 @@ public class DataLoader implements CommandLineRunner {
                     FeatureOption.builder().optionValue("LG").feature(brand).build(),
                     FeatureOption.builder().optionValue("기타").feature(brand).build()
             ));
-
             Feature color = Feature.builder().name("색상").quizQuestion("제품의 색상은 무엇인가요?").category(electronics).build();
             color.getOptions().addAll(List.of(
                     FeatureOption.builder().optionValue("블랙").feature(color).build(),
@@ -65,65 +107,90 @@ public class DataLoader implements CommandLineRunner {
             ));
             electronics.getFeatures().addAll(List.of(brand, color));
 
+            // --- 2. 기타 카테고리 ---
+            Category etcCategory = Category.builder().name("기타").iconUrl("http://example.com/etc-icon.png").build();
 
-            // --- 2. 지갑/카드 카테고리 ---
-            Category wallet = Category.builder().name("지갑/카드").iconUrl("https://cdn-icons-png.flaticon.com/128/4044/4044109.png").build();
-
-            Feature walletType = Feature.builder().name("종류").quizQuestion("어떤 종류의 지갑/카드인가요?").category(wallet).build();
-            walletType.getOptions().addAll(List.of(
-                    FeatureOption.builder().optionValue("반지갑").feature(walletType).build(),
-                    FeatureOption.builder().optionValue("장지갑").feature(walletType).build(),
-                    FeatureOption.builder().optionValue("카드지갑").feature(walletType).build(),
-                    FeatureOption.builder().optionValue("신분증/면허증").feature(walletType).build(),
-                    FeatureOption.builder().optionValue("신용/체크카드").feature(walletType).build()
-            ));
-
-            Feature walletColor = Feature.builder().name("색상").quizQuestion("지갑/카드의 색상은 무엇인가요?").category(wallet).build();
-            walletColor.getOptions().addAll(List.of(
-                    FeatureOption.builder().optionValue("블랙").feature(walletColor).build(),
-                    FeatureOption.builder().optionValue("브라운").feature(walletColor).build(),
-                    FeatureOption.builder().optionValue("네이비").feature(walletColor).build(),
-                    FeatureOption.builder().optionValue("기타").feature(walletColor).build()
-            ));
-            wallet.getFeatures().addAll(List.of(walletType, walletColor));
-
-            // --- 모든 카테고리 저장 ---
-            categoryRepository.saveAll(List.of(electronics, wallet));
-            log.info("카테고리 및 관련 특성 정보 초기화 완료!");
+            categoryRepository.saveAll(List.of(electronics, etcCategory));
+            log.info("카테고리 정보 초기화 완료!");
         } else {
             log.info("카테고리 정보가 이미 존재하여 초기화를 건너뜁니다.");
         }
     }
 
-    private void initSchoolAreaData() {
-        log.info("구역 정보를 초기화합니다.");
-        if (schoolAreaRepository.count() == 0) {
-            Polygon playground = geometryFactory.createPolygon(new Coordinate[]{
-                    new Coordinate(127.0752831, 37.5510817), new Coordinate(127.0742638, 37.5502523),
-                    new Coordinate(127.0749505, 37.5498356), new Coordinate(127.0759912, 37.5507372),
-                    new Coordinate(127.0752831, 37.5510817)
-            });
-            SchoolArea playgroundZone = new SchoolArea("세종대학교 운동장", playground);
-
-            Polygon sideRoad = geometryFactory.createPolygon(new Coordinate[]{
-                    new Coordinate(127.0738508, 37.5506351), new Coordinate(127.0742638, 37.5502523),
-                    new Coordinate(127.075326, 37.5511285), new Coordinate(127.0747198, 37.5516133),
-                    new Coordinate(127.0740868, 37.5510902), new Coordinate(127.0739902, 37.5510051),
-                    new Coordinate(127.0741565, 37.5508605), new Coordinate(127.0738508, 37.5506351)
-            });
-            SchoolArea sideRoadZone = new SchoolArea("세종대학교 운동장 옆 길", sideRoad);
-
-            Polygon aiCenter = geometryFactory.createPolygon(new Coordinate[]{
-                    new Coordinate(127.0754923, 37.551137), new Coordinate(127.0757605, 37.5508988),
-                    new Coordinate(127.076018, 37.5510647), new Coordinate(127.0757015, 37.5512986),
-                    new Coordinate(127.0754923, 37.551137)
-            });
-            SchoolArea aiCenterZone = new SchoolArea("세종대학교 AI 센터", aiCenter);
-
-            schoolAreaRepository.saveAll(Arrays.asList(playgroundZone, sideRoadZone, aiCenterZone));
-            log.info("개발용 임시 구역 정보 초기화 완료!");
+    private void initMemberData() {
+        log.info("회원 정보를 초기화합니다.");
+        if (memberRepository.count() == 0) {
+            Member member = Member.builder()
+                    .email("testuser@example.com")
+                    .nickname("테스트유저")
+                    .provider(Provider.GOOGLE)
+                    .providerId("123456789")
+                    .role(Role.USER)
+                    .emailConsent(true)
+                    .build();
+            memberRepository.save(member);
+            log.info("임시 회원 정보 초기화 완료!");
         } else {
-            log.info("구역 정보가 이미 존재하여 초기화를 건너뜁니다.");
+            log.info("회원 정보가 이미 존재하여 초기화를 건너뜁니다.");
+        }
+    }
+
+    private void initLostItemData() {
+        log.info("분실물 정보를 초기화합니다.");
+        if (lostItemRepository.count() == 0) {
+
+            Member member = memberRepository.findAll().get(0);
+            List<Category> categories = categoryRepository.findAll();
+            Category phoneCategory = categories.get(0);
+            Category etcCategory = categories.get(1);
+            List<SchoolArea> schoolAreas = schoolAreaRepository.findAll();
+            SchoolArea aiCenter = schoolAreas.get(2);
+            SchoolArea playground = schoolAreas.get(0);
+
+            // --- 1. 퀴즈가 있는 분실물 생성 (핸드폰) ---
+            LostItem phoneLostItem = new LostItem(
+                    "AI 센터 1층 로비 소파 위",
+                    "검정색 아이폰 15 프로입니다. 케이스는 투명색입니다.",
+                    "AI 센터 1층 안내데스크",
+                    phoneCategory,
+                    aiCenter
+            );
+            lostItemRepository.save(phoneLostItem);
+
+            LostItemImage phoneImage = LostItemImage.builder()
+                    .imageKey("https://zupzup-static-files.s3.ap-northeast-2.amazonaws.com/dev/iphone.webp")
+                    .imageOrder(1).lostItem(phoneLostItem).build();
+            lostItemImageRepository.save(phoneImage);
+
+            Feature brandFeature = phoneCategory.getFeatures().get(0);
+            FeatureOption appleOption = brandFeature.getOptions().get(1);
+            LostItemFeature lostItemBrand = LostItemFeature.builder().lostItem(phoneLostItem).feature(brandFeature)
+                    .selectedOption(appleOption).build();
+
+            Feature colorFeature = phoneCategory.getFeatures().get(1);
+            FeatureOption blackOption = colorFeature.getOptions().get(0);
+            LostItemFeature lostItemColor = LostItemFeature.builder().lostItem(phoneLostItem).feature(colorFeature)
+                    .selectedOption(blackOption).build();
+            lostItemFeatureRepository.saveAll(List.of(lostItemBrand, lostItemColor));
+
+            // --- 2. 퀴즈가 없는 분실물 생성 (기타) ---
+            LostItem etcLostItem = new LostItem(
+                    "운동장 스탠드 세 번째 줄",
+                    "검정색 3단 우산. 손잡이에 곰돌이 스티커가 붙어있음.",
+                    "학생회관 분실물 보관함",
+                    etcCategory,
+                    playground
+            );
+            lostItemRepository.save(etcLostItem);
+
+            LostItemImage umbrellaImage = LostItemImage.builder()
+                    .imageKey("https://zupzup-static-files.s3.ap-northeast-2.amazonaws.com/dev/umbrella.webp")
+                    .imageOrder(1).lostItem(etcLostItem).build();
+            lostItemImageRepository.save(umbrellaImage);
+
+            log.info("임시 분실물 정보 초기화 완료!");
+        } else {
+            log.info("분실물 정보가 이미 존재하여 초기화를 건너뜁니다.");
         }
     }
 }

--- a/src/main/java/com/greedy/zupzup/DataLoader.java
+++ b/src/main/java/com/greedy/zupzup/DataLoader.java
@@ -7,12 +7,13 @@ import com.greedy.zupzup.category.repository.CategoryRepository;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.domain.LostItemImage;
+import com.greedy.zupzup.lostitem.domain.LostItemStatus;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
-import com.greedy.zupzup.member.Member;
-import com.greedy.zupzup.member.Provider;
-import com.greedy.zupzup.member.Role;
+import com.greedy.zupzup.member.domain.Member;
+import com.greedy.zupzup.member.domain.Provider;
+import com.greedy.zupzup.member.domain.Role;
 import com.greedy.zupzup.member.repository.MemberRepository;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import com.greedy.zupzup.schoolarea.repository.SchoolAreaRepository;
@@ -29,7 +30,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
-import java.util.List;
 
 @Slf4j
 @Profile("dev")
@@ -175,13 +175,15 @@ public class DataLoader implements CommandLineRunner {
             SchoolArea playground = schoolAreas.get(0);
 
             // --- 1. 퀴즈가 있는 분실물 생성 (핸드폰) ---
-            LostItem phoneLostItem = new LostItem(
-                    "AI 센터 1층 로비 소파 위",
-                    "검정색 아이폰 15 프로입니다. 케이스는 투명색입니다.",
-                    "AI 센터 1층 안내데스크",
-                    phoneCategory,
-                    aiCenter
-            );
+            LostItem phoneLostItem = LostItem.builder()
+                    .foundAreaDetail("AI 센터 1층 로비 소파 위")
+                    .description("검정색 아이폰 15 프로입니다. 케이스는 투명색입니다.")
+                    .depositArea("AI 센터 1층 안내데스크")
+                    .status(LostItemStatus.REGISTERED)
+                    .category(phoneCategory)
+                    .foundArea(aiCenter)
+                    .finder(member)
+                    .build();
             lostItemRepository.save(phoneLostItem);
 
             LostItemImage phoneImage = LostItemImage.builder()
@@ -201,13 +203,15 @@ public class DataLoader implements CommandLineRunner {
             lostItemFeatureRepository.saveAll(List.of(lostItemBrand, lostItemColor));
 
             // --- 2. 퀴즈가 없는 분실물 생성 (기타) ---
-            LostItem etcLostItem = new LostItem(
-                    "운동장 스탠드 세 번째 줄",
-                    "검정색 3단 우산. 손잡이에 곰돌이 스티커가 붙어있음.",
-                    "학생회관 분실물 보관함",
-                    etcCategory,
-                    playground
-            );
+            LostItem etcLostItem = LostItem.builder()
+                    .foundAreaDetail("운동장 스탠드 세 번째 줄")
+                    .description("검정색 3단 우산. 손잡이에 곰돌이 스티커가 붙어있음.")
+                    .depositArea("학생회관 분실물 보관함")
+                    .status(LostItemStatus.REGISTERED)
+                    .category(etcCategory)
+                    .foundArea(playground)
+                    .finder(member)
+                    .build();
             lostItemRepository.save(etcLostItem);
 
             LostItemImage umbrellaImage = LostItemImage.builder()

--- a/src/main/java/com/greedy/zupzup/DataLoader.java
+++ b/src/main/java/com/greedy/zupzup/DataLoader.java
@@ -17,6 +17,7 @@ import com.greedy.zupzup.member.repository.MemberRepository;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import com.greedy.zupzup.schoolarea.repository.SchoolAreaRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
@@ -84,20 +85,47 @@ public class DataLoader implements CommandLineRunner {
         }
     }
 
+    private List<SchoolArea> createSchoolAreas() {
+        Polygon playground = geometryFactory.createPolygon(new Coordinate[]{
+                new Coordinate(127.0752831, 37.5510817), new Coordinate(127.0742638, 37.5502523),
+                new Coordinate(127.0749505, 37.5498356), new Coordinate(127.0759912, 37.5507372),
+                new Coordinate(127.0752831, 37.5510817)
+        });
+        SchoolArea playgroundZone = new SchoolArea("세종대학교 운동장", playground);
+
+        Polygon sideRoad = geometryFactory.createPolygon(new Coordinate[]{
+                new Coordinate(127.0738508, 37.5506351), new Coordinate(127.0742638, 37.5502523),
+                new Coordinate(127.075326, 37.5511285), new Coordinate(127.0747198, 37.5516133),
+                new Coordinate(127.0740868, 37.5510902), new Coordinate(127.0739902, 37.5510051),
+                new Coordinate(127.0741565, 37.5508605), new Coordinate(127.0738508, 37.5506351)
+        });
+        SchoolArea sideRoadZone = new SchoolArea("세종대학교 운동장 옆 길", sideRoad);
+
+        Polygon aiCenter = geometryFactory.createPolygon(new Coordinate[]{
+                new Coordinate(127.0754923, 37.551137), new Coordinate(127.0757605, 37.5508988),
+                new Coordinate(127.076018, 37.5510647), new Coordinate(127.0757015, 37.5512986),
+                new Coordinate(127.0754923, 37.551137)
+        });
+        SchoolArea aiCenterZone = new SchoolArea("세종대학교 AI 센터", aiCenter);
+
+        return schoolAreaRepository.saveAll(Arrays.asList(playgroundZone, sideRoadZone, aiCenterZone));
+    }
+
     private void initCategoryData() {
         log.info("카테고리 정보를 초기화합니다.");
         if (categoryRepository.count() == 0) {
-            // --- 1. 핸드폰(전자기기) 카테고리 ---
-            Category electronics = Category.builder().name("핸드폰")
-                    .iconUrl("https://cdn-icons-png.flaticon.com/128/519/519184.png").build();
-            Feature brand = Feature.builder().name("브랜드").quizQuestion("어떤 브랜드의 제품인가요?").category(electronics).build();
+            // --- 1. 핸드폰 카테고리 ---
+            Category phoneCategory = Category.builder().name("핸드폰").iconUrl("http://example.com/phone-icon.png")
+                    .build();
+            Feature brand = Feature.builder().name("브랜드").quizQuestion("어떤 브랜드의 제품인가요?").category(phoneCategory)
+                    .build();
             brand.getOptions().addAll(List.of(
                     FeatureOption.builder().optionValue("삼성").feature(brand).build(),
                     FeatureOption.builder().optionValue("애플").feature(brand).build(),
                     FeatureOption.builder().optionValue("LG").feature(brand).build(),
                     FeatureOption.builder().optionValue("기타").feature(brand).build()
             ));
-            Feature color = Feature.builder().name("색상").quizQuestion("제품의 색상은 무엇인가요?").category(electronics).build();
+            Feature color = Feature.builder().name("색상").quizQuestion("제품의 색상은 무엇인가요?").category(phoneCategory).build();
             color.getOptions().addAll(List.of(
                     FeatureOption.builder().optionValue("블랙").feature(color).build(),
                     FeatureOption.builder().optionValue("화이트").feature(color).build(),
@@ -105,12 +133,12 @@ public class DataLoader implements CommandLineRunner {
                     FeatureOption.builder().optionValue("골드").feature(color).build(),
                     FeatureOption.builder().optionValue("기타").feature(color).build()
             ));
-            electronics.getFeatures().addAll(List.of(brand, color));
+            phoneCategory.getFeatures().addAll(List.of(brand, color));
 
             // --- 2. 기타 카테고리 ---
             Category etcCategory = Category.builder().name("기타").iconUrl("http://example.com/etc-icon.png").build();
 
-            categoryRepository.saveAll(List.of(electronics, etcCategory));
+            categoryRepository.saveAll(List.of(phoneCategory, etcCategory));
             log.info("카테고리 정보 초기화 완료!");
         } else {
             log.info("카테고리 정보가 이미 존재하여 초기화를 건너뜁니다.");
@@ -138,7 +166,6 @@ public class DataLoader implements CommandLineRunner {
     private void initLostItemData() {
         log.info("분실물 정보를 초기화합니다.");
         if (lostItemRepository.count() == 0) {
-
             Member member = memberRepository.findAll().get(0);
             List<Category> categories = categoryRepository.findAll();
             Category phoneCategory = categories.get(0);

--- a/src/main/java/com/greedy/zupzup/DataLoader.java
+++ b/src/main/java/com/greedy/zupzup/DataLoader.java
@@ -182,7 +182,6 @@ public class DataLoader implements CommandLineRunner {
                     .status(LostItemStatus.REGISTERED)
                     .category(phoneCategory)
                     .foundArea(aiCenter)
-                    .finder(member)
                     .build();
             lostItemRepository.save(phoneLostItem);
 
@@ -210,7 +209,6 @@ public class DataLoader implements CommandLineRunner {
                     .status(LostItemStatus.REGISTERED)
                     .category(etcCategory)
                     .foundArea(playground)
-                    .finder(member)
                     .build();
             lostItemRepository.save(etcLostItem);
 

--- a/src/main/java/com/greedy/zupzup/TestDataLoader.java
+++ b/src/main/java/com/greedy/zupzup/TestDataLoader.java
@@ -1,6 +1,5 @@
 package com.greedy.zupzup;
 
-
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.domain.Feature;
 import com.greedy.zupzup.category.domain.FeatureOption;
@@ -22,10 +21,10 @@ import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
-@Profile("dev")
+@Profile("test")
 @Component
 @RequiredArgsConstructor
-public class DataLoader implements CommandLineRunner {
+public class TestDataLoader implements CommandLineRunner {
 
     private final SchoolAreaRepository schoolAreaRepository;
     private final CategoryRepository categoryRepository;
@@ -96,7 +95,7 @@ public class DataLoader implements CommandLineRunner {
     }
 
     private void initSchoolAreaData() {
-        log.info("구역 정보를 초기화합니다.");
+        log.info("데이터베이스 임시 구역 정보를 초기화합니다.");
         if (schoolAreaRepository.count() == 0) {
             Polygon playground = geometryFactory.createPolygon(new Coordinate[]{
                     new Coordinate(127.0752831, 37.5510817), new Coordinate(127.0742638, 37.5502523),
@@ -126,4 +125,5 @@ public class DataLoader implements CommandLineRunner {
             log.info("구역 정보가 이미 존재하여 초기화를 건너뜁니다.");
         }
     }
+
 }

--- a/src/main/java/com/greedy/zupzup/alert/KeywordAlert.java
+++ b/src/main/java/com/greedy/zupzup/alert/KeywordAlert.java
@@ -1,7 +1,7 @@
 package com.greedy.zupzup.alert;
 
 import com.greedy.zupzup.global.BaseTimeEntity;
-import com.greedy.zupzup.member.Member;
+import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.category.domain.Category;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/greedy/zupzup/category/domain/Category.java
+++ b/src/main/java/com/greedy/zupzup/category/domain/Category.java
@@ -25,6 +25,8 @@ import jakarta.persistence.Table;
 @Builder
 public class Category extends BaseTimeEntity {
 
+    private static final String ETC_CATEGORY_NAME = "기타";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -40,4 +42,8 @@ public class Category extends BaseTimeEntity {
             orphanRemoval = true)
     @Builder.Default
     private List<Feature> features = new ArrayList<>();
+
+    public boolean isNotQuizCategory() {
+        return ETC_CATEGORY_NAME.equals(this.name);
+    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
@@ -53,10 +53,6 @@ public class LostItem extends BaseTimeEntity {
     private LocalDate pledgedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "finder_id", nullable = false)
-    private Member finder;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
@@ -2,7 +2,7 @@ package com.greedy.zupzup.lostitem.domain;
 
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.global.BaseTimeEntity;
-import com.greedy.zupzup.member.Member;
+import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -67,10 +67,6 @@ public class LostItem extends BaseTimeEntity {
     @OneToMany(mappedBy = "lostItem")
     private List<LostItemImage> images = new ArrayList<>();
 
-    public boolean isNotQuizCategory() {
-        return this.category.isNotQuizCategory();
-    }
-
     public LostItem(String foundAreaDetail, String description, String depositArea, Category category, SchoolArea foundArea) {
         this.foundAreaDetail = foundAreaDetail;
         this.description = description;
@@ -79,5 +75,18 @@ public class LostItem extends BaseTimeEntity {
         this.pledgedAt = null;
         this.category = category;
         this.foundArea = foundArea;
+    }
+
+    public boolean isNotQuizCategory() {
+        return this.category.isNotQuizCategory();
+    }
+
+    public boolean isPledgeable() {
+        return this.status == LostItemStatus.REGISTERED;
+    }
+
+    public void pledge() {
+        this.status = LostItemStatus.PLEDGED;
+        this.pledgedAt = LocalDate.now();
     }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
@@ -14,8 +14,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -60,6 +63,9 @@ public class LostItem extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "found_area_id", nullable = false)
     private SchoolArea foundArea;
+
+    @OneToMany(mappedBy = "lostItem")
+    private List<LostItemImage> images = new ArrayList<>();
 
     public boolean isNotQuizCategory() {
         return this.category.isNotQuizCategory();

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
@@ -2,6 +2,7 @@ package com.greedy.zupzup.lostitem.domain;
 
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.global.BaseTimeEntity;
+import com.greedy.zupzup.member.Member;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -49,12 +50,20 @@ public class LostItem extends BaseTimeEntity {
     private LocalDate pledgedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "finder_id", nullable = false)
+    private Member finder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "found_area_id", nullable = false)
     private SchoolArea foundArea;
+
+    public boolean isNotQuizCategory() {
+        return this.category.isNotQuizCategory();
+    }
 
     public LostItem(String foundAreaDetail, String description, String depositArea, Category category, SchoolArea foundArea) {
         this.foundAreaDetail = foundAreaDetail;

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItemFeature.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItemFeature.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.UniqueConstraint;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,5 +48,17 @@ public class LostItemFeature extends BaseTimeEntity {
         this.lostItem = lostItem;
         this.feature = feature;
         this.selectedOption = selectedOption;
+    }
+
+    public Long getFeatureId() {
+        return this.feature.getId();
+    }
+
+    public Long getSelectedOptionId() {
+        return this.selectedOption.getId();
+    }
+
+    public List<FeatureOption> getFeatureOptions() {
+        return this.feature.getOptions();
     }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum LostItemException implements ExceptionCode {
 
     LOST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "분실물 없음", "해당 ID의 분실물을 찾을 수 없습니다."),
-    LOST_ITEM_IMAGE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "분실물 이미지 없음", "분실물에 이미지가 등록되지 않았습니다.");
-
+    LOST_ITEM_IMAGE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "분실물 이미지 없음", "분실물에 이미지가 등록되지 않았습니다."),
+    ALREADY_PLEDGED(HttpStatus.CONFLICT, "이미 서약된 물품", "분실물이 이미 서약(PLEDGED) 상태이므로, 더 이상 작업을 수행할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String title;

--- a/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
@@ -1,0 +1,17 @@
+package com.greedy.zupzup.lostitem.exception;
+
+import com.greedy.zupzup.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum LostItemException implements ExceptionCode {
+
+    LOST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "분실물 없음", "해당 ID의 분실물을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+}

--- a/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum LostItemException implements ExceptionCode {
 
-    LOST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "분실물 없음", "해당 ID의 분실물을 찾을 수 없습니다.");
+    LOST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "분실물 없음", "해당 ID의 분실물을 찾을 수 없습니다."),
+    LOST_ITEM_IMAGE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "분실물 이미지 없음", "분실물에 이미지가 등록되지 않았습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String title;

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemFeatureRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemFeatureRepository.java
@@ -1,7 +1,17 @@
 package com.greedy.zupzup.lostitem.repository;
 
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LostItemFeatureRepository extends JpaRepository<LostItemFeature, Long> {
+
+    @Query("""
+            select lif from LostItemFeature lif
+            join fetch lif.feature f
+            join fetch f.options
+            where lif.lostItem.id = :lostItemId
+            """)
+    List<LostItemFeature> findWithFeatureAndOptionsByLostItemId(Long lostItemId);
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemRepository.java
@@ -1,6 +1,8 @@
 package com.greedy.zupzup.lostitem.repository;
 
+import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.lostitem.domain.LostItem;
+import com.greedy.zupzup.lostitem.exception.LostItemException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +15,14 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
             where li.id = :lostItemId
             """)
     Optional<LostItem> findWithCategoryById(Long lostItemId);
+
+    default LostItem getById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
+    }
+
+    default LostItem getWithCategoryById(Long id) {
+        return findWithCategoryById(id)
+                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemRepository.java
@@ -1,8 +1,16 @@
 package com.greedy.zupzup.lostitem.repository;
 
 import com.greedy.zupzup.lostitem.domain.LostItem;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LostItemRepository extends JpaRepository<LostItem, Long> {
 
+    @Query("""
+            select li from LostItem li
+            join fetch li.category
+            where li.id = :lostItemId
+            """)
+    Optional<LostItem> findWithCategoryById(Long lostItemId);
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemRepository.java
@@ -4,4 +4,5 @@ import com.greedy.zupzup.lostitem.domain.LostItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LostItemRepository extends JpaRepository<LostItem, Long> {
+
 }

--- a/src/main/java/com/greedy/zupzup/member/domain/Member.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Member.java
@@ -1,4 +1,4 @@
-package com.greedy.zupzup.member;
+package com.greedy.zupzup.member.domain;
 
 import com.greedy.zupzup.global.BaseTimeEntity;
 import lombok.*;

--- a/src/main/java/com/greedy/zupzup/member/domain/Provider.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Provider.java
@@ -1,4 +1,4 @@
-package com.greedy.zupzup.member;
+package com.greedy.zupzup.member.domain;
 
 public enum Provider {
     GOOGLE,

--- a/src/main/java/com/greedy/zupzup/member/domain/Role.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Role.java
@@ -1,4 +1,4 @@
-package com.greedy.zupzup.member;
+package com.greedy.zupzup.member.domain;
 
 public enum Role {
     USER,

--- a/src/main/java/com/greedy/zupzup/member/exception/MemberException.java
+++ b/src/main/java/com/greedy/zupzup/member/exception/MemberException.java
@@ -1,0 +1,18 @@
+package com.greedy.zupzup.member.exception;
+
+import com.greedy.zupzup.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberException implements ExceptionCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없음", "해당 ID의 회원을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+}
+

--- a/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
+++ b/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
@@ -1,8 +1,14 @@
 package com.greedy.zupzup.member.repository;
 
+import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.member.domain.Member;
+import com.greedy.zupzup.member.exception.MemberException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    default Member getById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new ApplicationException(MemberException.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
+++ b/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
 package com.greedy.zupzup.member.repository;
 
-import com.greedy.zupzup.member.Member;
+import com.greedy.zupzup.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {

--- a/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
+++ b/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.greedy.zupzup.member.repository;
+
+import com.greedy.zupzup.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/greedy/zupzup/pledge/Pledge.java
+++ b/src/main/java/com/greedy/zupzup/pledge/Pledge.java
@@ -2,7 +2,7 @@ package com.greedy.zupzup.pledge;
 
 import com.greedy.zupzup.global.BaseTimeEntity;
 import com.greedy.zupzup.lostitem.domain.LostItem;
-import com.greedy.zupzup.member.Member;
+import com.greedy.zupzup.member.domain.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/greedy/zupzup/pledge/application/PledgeService.java
+++ b/src/main/java/com/greedy/zupzup/pledge/application/PledgeService.java
@@ -4,7 +4,6 @@ import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.exception.LostItemException;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
-import com.greedy.zupzup.member.exception.MemberException;
 import com.greedy.zupzup.member.repository.MemberRepository;
 import com.greedy.zupzup.pledge.domain.Pledge;
 import com.greedy.zupzup.member.domain.Member;
@@ -33,7 +32,7 @@ public class PledgeService {
         Member member = memberRepository.getById(memberId);
         LostItem lostItem = lostItemRepository.getById(lostItemId);
 
-        validatePledgeCreation(lostItem, memberId);
+        validatePledgeCreation(lostItem, member);
 
         Pledge pledge = savePledge(lostItem, member);
         lostItem.pledge();
@@ -41,13 +40,13 @@ public class PledgeService {
         return pledge;
     }
 
-    private void validatePledgeCreation(LostItem lostItem, Long memberId) {
+    private void validatePledgeCreation(LostItem lostItem, Member member) {
         if (!lostItem.isPledgeable()) {
             throw new ApplicationException(LostItemException.ALREADY_PLEDGED);
         }
 
         if (!lostItem.isNotQuizCategory()) {
-            QuizAttempt quizAttempt = quizAttemptRepository.getByLostItemIdAndMemberId(lostItem.getId(), memberId);
+            QuizAttempt quizAttempt = quizAttemptRepository.getByLostItemIdAndMemberId(lostItem.getId(), member.getId());
             if (!quizAttempt.getIsCorrect()) {
                 throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
             }

--- a/src/main/java/com/greedy/zupzup/pledge/application/PledgeService.java
+++ b/src/main/java/com/greedy/zupzup/pledge/application/PledgeService.java
@@ -30,10 +30,8 @@ public class PledgeService {
     @Transactional
     public Pledge createPledge(Long lostItemId, Long memberId) {
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApplicationException(MemberException.MEMBER_NOT_FOUND));
-        LostItem lostItem = lostItemRepository.findById(lostItemId)
-                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
+        Member member = memberRepository.getById(memberId);
+        LostItem lostItem = lostItemRepository.getById(lostItemId);
 
         validatePledgeCreation(lostItem, memberId);
 
@@ -49,8 +47,7 @@ public class PledgeService {
         }
 
         if (!lostItem.isNotQuizCategory()) {
-            QuizAttempt quizAttempt = quizAttemptRepository.findByLostItemIdAndMemberId(lostItem.getId(), memberId)
-                    .orElseThrow(() -> new ApplicationException(QuizException.QUIZ_NOT_ATTEMPTED));
+            QuizAttempt quizAttempt = quizAttemptRepository.getByLostItemIdAndMemberId(lostItem.getId(), memberId);
             if (!quizAttempt.getIsCorrect()) {
                 throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
             }

--- a/src/main/java/com/greedy/zupzup/pledge/application/PledgeService.java
+++ b/src/main/java/com/greedy/zupzup/pledge/application/PledgeService.java
@@ -50,15 +50,17 @@ public class PledgeService {
     }
 
     private void validatePledgeCreation(LostItem lostItem, Long memberId) {
-        QuizAttempt quizAttempt = quizAttemptRepository.findByLostItemIdAndMemberId(lostItem.getId(), memberId)
-                .orElseThrow(() -> new ApplicationException(PledgeException.QUIZ_NOT_PASSED));
-
-        if (!quizAttempt.getIsCorrect()) {
-            throw new ApplicationException(PledgeException.QUIZ_NOT_PASSED);
-        }
-
         if (!lostItem.isPledgeable()) {
             throw new ApplicationException(PledgeException.CANNOT_PLEDGE_STATUS);
+        }
+
+        if (!lostItem.isNotQuizCategory()) {
+            QuizAttempt quizAttempt = quizAttemptRepository.findByLostItemIdAndMemberId(lostItem.getId(), memberId)
+                    .orElseThrow(() -> new ApplicationException(PledgeException.QUIZ_NOT_PASSED));
+
+            if (!quizAttempt.getIsCorrect()) {
+                throw new ApplicationException(PledgeException.QUIZ_NOT_PASSED);
+            }
         }
     }
 }

--- a/src/main/java/com/greedy/zupzup/pledge/domain/Pledge.java
+++ b/src/main/java/com/greedy/zupzup/pledge/domain/Pledge.java
@@ -1,4 +1,4 @@
-package com.greedy.zupzup.pledge;
+package com.greedy.zupzup.pledge.domain;
 
 import com.greedy.zupzup.global.BaseTimeEntity;
 import com.greedy.zupzup.lostitem.domain.LostItem;

--- a/src/main/java/com/greedy/zupzup/pledge/exception/PledgeException.java
+++ b/src/main/java/com/greedy/zupzup/pledge/exception/PledgeException.java
@@ -1,0 +1,18 @@
+package com.greedy.zupzup.pledge.exception;
+
+import com.greedy.zupzup.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PledgeException implements ExceptionCode {
+
+    QUIZ_NOT_PASSED(HttpStatus.FORBIDDEN, "퀴즈 미통과", "퀴즈를 통과해야 서약할 수 있습니다."),
+    CANNOT_PLEDGE_STATUS(HttpStatus.CONFLICT, "서약 불가 상태", "이미 서약되었거나 처리할 수 없는 상태의 분실물입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+}

--- a/src/main/java/com/greedy/zupzup/pledge/presentation/PledgeController.java
+++ b/src/main/java/com/greedy/zupzup/pledge/presentation/PledgeController.java
@@ -1,0 +1,31 @@
+package com.greedy.zupzup.pledge.presentation;
+
+import com.greedy.zupzup.pledge.application.PledgeService;
+import com.greedy.zupzup.pledge.domain.Pledge;
+import com.greedy.zupzup.pledge.presentation.dto.PledgeResponse;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/lost-items/{lostItemId}/pledge")
+@RequiredArgsConstructor
+public class PledgeController {
+
+    private final PledgeService pledgeService;
+
+    @PostMapping
+    public ResponseEntity<PledgeResponse> createPledge(
+            @PathVariable Long lostItemId,
+            Long memberId
+    ) {
+        Pledge pledge = pledgeService.createPledge(lostItemId, memberId);
+        return ResponseEntity
+                .created(URI.create("/api/pledges/" + pledge.getId()))
+                .body(PledgeResponse.from(pledge));
+    }
+}

--- a/src/main/java/com/greedy/zupzup/pledge/presentation/dto/PledgeResponse.java
+++ b/src/main/java/com/greedy/zupzup/pledge/presentation/dto/PledgeResponse.java
@@ -1,0 +1,17 @@
+package com.greedy.zupzup.pledge.presentation.dto;
+
+import com.greedy.zupzup.pledge.domain.Pledge;
+
+public record PledgeResponse(
+        Long pledgeId,
+        String message,
+        String foundAreaDetail
+) {
+    public static PledgeResponse from(Pledge pledge) {
+        return new PledgeResponse(
+                pledge.getId(),
+                "서약이 완료되었습니다.",
+                pledge.getLostItem().getDepositArea()
+        );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/pledge/presentation/dto/PledgeResponse.java
+++ b/src/main/java/com/greedy/zupzup/pledge/presentation/dto/PledgeResponse.java
@@ -5,7 +5,7 @@ import com.greedy.zupzup.pledge.domain.Pledge;
 public record PledgeResponse(
         Long pledgeId,
         String message,
-        String foundAreaDetail
+        String depositArea
 ) {
     public static PledgeResponse from(Pledge pledge) {
         return new PledgeResponse(

--- a/src/main/java/com/greedy/zupzup/pledge/repository/PledgeRepository.java
+++ b/src/main/java/com/greedy/zupzup/pledge/repository/PledgeRepository.java
@@ -1,0 +1,8 @@
+package com.greedy.zupzup.pledge.repository;
+
+import com.greedy.zupzup.pledge.domain.Pledge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PledgeRepository extends JpaRepository<Pledge, Long> {
+
+}

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
@@ -9,7 +9,6 @@ import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.member.repository.MemberRepository;
-import com.greedy.zupzup.pledge.exception.PledgeException;
 import com.greedy.zupzup.quiz.application.dto.OptionDto;
 import com.greedy.zupzup.quiz.application.dto.QuizDto;
 import com.greedy.zupzup.quiz.exception.QuizException;

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
@@ -34,7 +34,7 @@ public class QuizGenerationService {
     private static final String ETC_OPTION_TEXT = "기타";
 
     @Transactional(readOnly = true)
-    public List<QuizDto> generateLostItemQuizzes(Long lostItemId, Long memberId) {
+    public List<QuizDto> getLostItemQuizzes(Long lostItemId, Long memberId) {
         validateQuizGeneration(lostItemId, memberId);
 
         LostItem lostItem = lostItemRepository.findWithCategoryById(lostItemId)

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
@@ -57,8 +57,7 @@ public class QuizGenerationService {
     }
 
     private LostItem findAndValidateLostItem(Long lostItemId) {
-        LostItem lostItem = lostItemRepository.findWithCategoryById(lostItemId)
-                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
+        LostItem lostItem = lostItemRepository.getWithCategoryById(lostItemId);
 
         if (!lostItem.isPledgeable()) {
             throw new ApplicationException(LostItemException.ALREADY_PLEDGED);

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class QuizService {
+public class QuizGenerationService {
 
     private final LostItemRepository lostItemRepository;
     private final LostItemFeatureRepository lostItemFeatureRepository;

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizService.java
@@ -2,6 +2,7 @@ package com.greedy.zupzup.quiz.application;
 
 import com.greedy.zupzup.category.domain.FeatureOption;
 import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.exception.LostItemException;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
@@ -29,15 +30,22 @@ public class QuizService {
     private static final int QUIZ_OPTIONS_COUNT = 4;
     private static final int CORRECT_ANSWER_COUNT = 1;
     private static final int NUMBER_OF_WRONG_OPTIONS = QUIZ_OPTIONS_COUNT - CORRECT_ANSWER_COUNT;
+    private static final String ETC_CATEGORY_NAME = "기타";
     private static final String ETC_OPTION_TEXT = "기타";
 
     @Transactional(readOnly = true)
     public List<QuizDto> generateLostItemQuizzes(Long lostItemId, Long memberId) {
         validateQuizGeneration(lostItemId, memberId);
 
+        LostItem lostItem = lostItemRepository.findWithCategoryById(lostItemId)
+                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
+
+        if (lostItem.isNotQuizCategory()) {
+            return Collections.emptyList();
+        }
+
         List<LostItemFeature> lostItemFeatures = lostItemFeatureRepository.findWithFeatureAndOptionsByLostItemId(
                 lostItemId);
-
         return lostItemFeatures.stream()
                 .map(this::createQuizDto)
                 .collect(Collectors.toList());

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizService.java
@@ -1,0 +1,70 @@
+package com.greedy.zupzup.quiz.application;
+
+import com.greedy.zupzup.category.domain.FeatureOption;
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.lostitem.domain.LostItemFeature;
+import com.greedy.zupzup.lostitem.exception.LostItemException;
+import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemRepository;
+import com.greedy.zupzup.quiz.application.dto.OptionDto;
+import com.greedy.zupzup.quiz.application.dto.QuizDto;
+import com.greedy.zupzup.quiz.exception.QuizException;
+import com.greedy.zupzup.quiz.repository.QuizAttemptRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+
+    private final LostItemRepository lostItemRepository;
+    private final LostItemFeatureRepository lostItemFeatureRepository;
+    private final QuizAttemptRepository quizAttemptRepository;
+
+    @Transactional(readOnly = true)
+    public List<QuizDto> generateLostItemQuizzes(Long lostItemId, Long memberId) {
+        validateQuizGeneration(lostItemId, memberId);
+
+        List<LostItemFeature> lostItemFeatures = lostItemFeatureRepository.findWithFeatureAndOptionsByLostItemId(
+                lostItemId);
+
+        return lostItemFeatures.stream()
+                .map(this::createQuizDto)
+                .collect(Collectors.toList());
+    }
+
+    private void validateQuizGeneration(Long lostItemId, Long memberId) {
+        if (!lostItemRepository.existsById(lostItemId)) {
+            throw new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND);
+        }
+        if (quizAttemptRepository.existsByLostItemIdAndMemberId(lostItemId, memberId)) {
+            throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
+        }
+    }
+
+    private QuizDto createQuizDto(LostItemFeature lostItemFeature) {
+        List<FeatureOption> allOptions = lostItemFeature.getFeature().getOptions();
+        FeatureOption correctAnswer = lostItemFeature.getSelectedOption();
+
+        List<FeatureOption> selectedOptions = allOptions.stream()
+                .filter(option -> !option.equals(correctAnswer))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), collected -> {
+                    Collections.shuffle(collected);
+                    return collected.stream().limit(3);
+                }))
+                .collect(Collectors.toList());
+        selectedOptions.add(correctAnswer);
+        Collections.shuffle(selectedOptions);
+
+        List<OptionDto> optionDtos = selectedOptions.stream()
+                .map(option -> new OptionDto(option.getId(), option.getOptionValue()))
+                .toList();
+
+        return new QuizDto(lostItemFeature.getFeature().getId(), lostItemFeature.getFeature().getQuizQuestion(),
+                optionDtos);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
@@ -7,7 +7,6 @@ import com.greedy.zupzup.lostitem.exception.LostItemException;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.member.domain.Member;
-import com.greedy.zupzup.member.exception.MemberException;
 import com.greedy.zupzup.member.repository.MemberRepository;
 import com.greedy.zupzup.quiz.application.dto.AnswerCommand;
 import com.greedy.zupzup.quiz.application.dto.QuizResultDto;

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
@@ -9,7 +9,6 @@ import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.member.exception.MemberException;
 import com.greedy.zupzup.member.repository.MemberRepository;
-import com.greedy.zupzup.pledge.exception.PledgeException;
 import com.greedy.zupzup.quiz.application.dto.AnswerCommand;
 import com.greedy.zupzup.quiz.application.dto.QuizResultDto;
 import com.greedy.zupzup.quiz.domain.QuizAttempt;
@@ -36,10 +35,8 @@ public class QuizSubmissionService {
     @Transactional
     public QuizResultDto submitQuizAnswers(Long lostItemId, Long memberId, List<AnswerCommand> answers) {
 
-        LostItem lostItem = lostItemRepository.findById(lostItemId)
-                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApplicationException(MemberException.MEMBER_NOT_FOUND));
+        LostItem lostItem = lostItemRepository.getById(lostItemId);
+        Member member = memberRepository.getById(memberId);
 
         validateSubmissionPossibility(lostItem, member);
 

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
@@ -1,0 +1,83 @@
+package com.greedy.zupzup.quiz.application;
+
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.lostitem.domain.LostItem;
+import com.greedy.zupzup.lostitem.domain.LostItemFeature;
+import com.greedy.zupzup.lostitem.exception.LostItemException;
+import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemRepository;
+import com.greedy.zupzup.member.domain.Member;
+import com.greedy.zupzup.member.repository.MemberRepository;
+import com.greedy.zupzup.quiz.application.dto.AnswerCommand;
+import com.greedy.zupzup.quiz.application.dto.QuizResultDto;
+import com.greedy.zupzup.quiz.domain.QuizAttempt;
+import com.greedy.zupzup.quiz.exception.QuizException;
+import com.greedy.zupzup.quiz.repository.QuizAttemptRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QuizSubmissionService {
+
+    private final LostItemRepository lostItemRepository;
+    private final LostItemFeatureRepository lostItemFeatureRepository;
+    private final QuizAttemptRepository quizAttemptRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public QuizResultDto submitQuizAnswers(Long lostItemId, Long memberId, List<AnswerCommand> answers) {
+        validate(lostItemId, memberId);
+
+        List<LostItemFeature> correctAnswers = lostItemFeatureRepository.findWithFeatureAndOptionsByLostItemId(
+                lostItemId);
+        boolean isCorrect = checkAnswers(correctAnswers, answers);
+
+        saveQuizAttempt(lostItemId, memberId, isCorrect);
+
+        LostItem lostItem = lostItemRepository.getReferenceById(lostItemId);
+        return isCorrect ? QuizResultDto.correct(lostItem) : QuizResultDto.incorrect();
+    }
+
+    private void validate(Long lostItemId, Long memberId) {
+        if (!lostItemRepository.existsById(lostItemId)) {
+            throw new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND);
+        }
+        if (quizAttemptRepository.existsByLostItemIdAndMemberId(lostItemId, memberId)) {
+            throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
+        }
+    }
+
+    private void saveQuizAttempt(Long lostItemId, Long memberId, boolean isCorrect) {
+        Member member = memberRepository.getReferenceById(memberId);
+        LostItem lostItem = lostItemRepository.getReferenceById(lostItemId);
+        QuizAttempt attempt = QuizAttempt.builder()
+                .member(member)
+                .lostItem(lostItem)
+                .isCorrect(isCorrect)
+                .build();
+        quizAttemptRepository.save(attempt);
+    }
+
+    private boolean checkAnswers(List<LostItemFeature> correctAnswers, List<AnswerCommand> submittedAnswers) {
+        if (correctAnswers.size() != submittedAnswers.size()) {
+            return false;
+        }
+
+        Map<Long, Long> correctAnswerMap = correctAnswers.stream()
+                .collect(Collectors.toMap(
+                        answer -> answer.getFeature().getId(),
+                        answer -> answer.getSelectedOption().getId()
+                ));
+
+        return submittedAnswers.stream()
+                .allMatch(submitted ->
+                        correctAnswerMap.getOrDefault(submitted.featureId(), -1L)
+                                .equals(submitted.selectedOptionId())
+                );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
@@ -41,7 +41,7 @@ public class QuizSubmissionService {
         validateSubmissionPossibility(lostItem, member);
 
         List<LostItemFeature> correctFeatures = lostItemFeatureRepository.findWithFeatureAndOptionsByLostItemId(
-                lostItemId);
+                lostItem.getId());
         Map<Long, Long> correctAnswerMap = createCorrectAnswerMap(correctFeatures);
         boolean isCorrect = checkAnswers(correctAnswerMap, answers, correctFeatures.size());
 

--- a/src/main/java/com/greedy/zupzup/quiz/application/dto/AnswerCommand.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/dto/AnswerCommand.java
@@ -1,0 +1,13 @@
+package com.greedy.zupzup.quiz.application.dto;
+
+import com.greedy.zupzup.quiz.presentation.dto.AnswerRequest;
+
+public record AnswerCommand(
+        Long featureId,
+        Long selectedOptionId
+) {
+
+    public static AnswerCommand from(AnswerRequest request) {
+        return new AnswerCommand(request.featureId(), request.selectedOptionId());
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/application/dto/LostItemDetailDto.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/dto/LostItemDetailDto.java
@@ -1,0 +1,20 @@
+package com.greedy.zupzup.quiz.application.dto;
+
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.lostitem.domain.LostItem;
+import com.greedy.zupzup.lostitem.domain.LostItemImage;
+import com.greedy.zupzup.lostitem.exception.LostItemException;
+
+public record LostItemDetailDto(
+        String imageUrl,
+        String description
+) {
+
+    public static LostItemDetailDto from(LostItem lostItem) {
+        String imageUrl = lostItem.getImages().stream()
+                .findFirst()
+                .map(LostItemImage::getImageKey)
+                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_IMAGE_NOT_FOUND));
+        return new LostItemDetailDto(imageUrl, lostItem.getDescription());
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/application/dto/OptionDto.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/dto/OptionDto.java
@@ -1,8 +1,13 @@
 package com.greedy.zupzup.quiz.application.dto;
 
+import com.greedy.zupzup.category.domain.FeatureOption;
+
 public record OptionDto(
         Long id,
         String text
-){
+) {
 
+    public static OptionDto from(FeatureOption featureOption) {
+        return new OptionDto(featureOption.getId(), featureOption.getOptionValue());
+    }
 }

--- a/src/main/java/com/greedy/zupzup/quiz/application/dto/OptionDto.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/dto/OptionDto.java
@@ -1,0 +1,8 @@
+package com.greedy.zupzup.quiz.application.dto;
+
+public record OptionDto(
+        Long id,
+        String text
+){
+
+}

--- a/src/main/java/com/greedy/zupzup/quiz/application/dto/QuizDto.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/dto/QuizDto.java
@@ -1,0 +1,11 @@
+package com.greedy.zupzup.quiz.application.dto;
+
+import java.util.List;
+
+public record QuizDto(
+        Long featureId,
+        String question,
+        List<OptionDto> options
+) {
+
+}

--- a/src/main/java/com/greedy/zupzup/quiz/application/dto/QuizDto.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/dto/QuizDto.java
@@ -1,5 +1,6 @@
 package com.greedy.zupzup.quiz.application.dto;
 
+import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import java.util.List;
 
 public record QuizDto(
@@ -8,4 +9,11 @@ public record QuizDto(
         List<OptionDto> options
 ) {
 
+    public static QuizDto of(LostItemFeature lostItemFeature, List<OptionDto> options) {
+        return new QuizDto(
+                lostItemFeature.getFeature().getId(),
+                lostItemFeature.getFeature().getQuizQuestion(),
+                options
+        );
+    }
 }

--- a/src/main/java/com/greedy/zupzup/quiz/application/dto/QuizResultDto.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/dto/QuizResultDto.java
@@ -1,0 +1,16 @@
+package com.greedy.zupzup.quiz.application.dto;
+
+import com.greedy.zupzup.lostitem.domain.LostItem;
+
+public record QuizResultDto(
+        boolean correct,
+        LostItemDetailDto detail
+) {
+    public static QuizResultDto correct(LostItem lostItem) {
+        return new QuizResultDto(true, LostItemDetailDto.from(lostItem));
+    }
+
+    public static QuizResultDto incorrect() {
+        return new QuizResultDto(false, null);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/domain/QuizAttempt.java
+++ b/src/main/java/com/greedy/zupzup/quiz/domain/QuizAttempt.java
@@ -1,4 +1,4 @@
-package com.greedy.zupzup.quiz;
+package com.greedy.zupzup.quiz.domain;
 
 import com.greedy.zupzup.global.BaseTimeEntity;
 import com.greedy.zupzup.lostitem.domain.LostItem;

--- a/src/main/java/com/greedy/zupzup/quiz/domain/QuizAttempt.java
+++ b/src/main/java/com/greedy/zupzup/quiz/domain/QuizAttempt.java
@@ -2,7 +2,7 @@ package com.greedy.zupzup.quiz.domain;
 
 import com.greedy.zupzup.global.BaseTimeEntity;
 import com.greedy.zupzup.lostitem.domain.LostItem;
-import com.greedy.zupzup.member.Member;
+import com.greedy.zupzup.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/greedy/zupzup/quiz/exception/QuizException.java
+++ b/src/main/java/com/greedy/zupzup/quiz/exception/QuizException.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum QuizException implements ExceptionCode {
 
-    QUIZ_ATTEMPT_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "퀴즈 시도 횟수 초과", "퀴즈 시도 횟수를 초과하여 더 이상 시도할 수 없습니다.");
+    QUIZ_ATTEMPT_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "퀴즈 시도 횟수 초과", "퀴즈 시도 횟수를 초과하여 더 이상 시도할 수 없습니다."),
+    QUIZ_NOT_ATTEMPTED(HttpStatus.BAD_REQUEST, "퀴즈 미시도", "퀴즈를 시도하지 않아 서약을 진행할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String title;

--- a/src/main/java/com/greedy/zupzup/quiz/exception/QuizException.java
+++ b/src/main/java/com/greedy/zupzup/quiz/exception/QuizException.java
@@ -1,0 +1,17 @@
+package com.greedy.zupzup.quiz.exception;
+
+import com.greedy.zupzup.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum QuizException implements ExceptionCode {
+
+    QUIZ_ATTEMPT_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "퀴즈 시도 횟수 초과", "퀴즈 시도 횟수를 초과하여 더 이상 시도할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/QuizController.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/QuizController.java
@@ -1,0 +1,26 @@
+package com.greedy.zupzup.quiz.presentation;
+
+import com.greedy.zupzup.quiz.application.QuizService;
+import com.greedy.zupzup.quiz.application.dto.QuizDto;
+import com.greedy.zupzup.quiz.presentation.dto.QuizzesResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @GetMapping("/api/lost-items/{lostItemId}/quizzes")
+    public ResponseEntity<QuizzesResponse> generateLostItemQuizzes(
+            @PathVariable Long lostItemId,
+            Long memberId) {
+        List<QuizDto> quizDtos = quizService.generateLostItemQuizzes(lostItemId, memberId);
+        return ResponseEntity.ok(QuizzesResponse.from(quizDtos));
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/QuizController.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/QuizController.java
@@ -27,8 +27,8 @@ public class QuizController {
     private final QuizSubmissionService quizSubmissionService;
 
     @GetMapping
-    public ResponseEntity<QuizzesResponse> generateLostItemQuizzes(@PathVariable Long lostItemId, Long memberId) {
-        List<QuizDto> quizDtos = quizGenerationService.generateLostItemQuizzes(lostItemId, memberId);
+    public ResponseEntity<QuizzesResponse> getLostItemQuizzes(@PathVariable Long lostItemId, Long memberId) {
+        List<QuizDto> quizDtos = quizGenerationService.getLostItemQuizzes(lostItemId, memberId);
         return ResponseEntity.ok(QuizzesResponse.from(quizDtos));
     }
 

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/QuizController.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/QuizController.java
@@ -1,26 +1,41 @@
 package com.greedy.zupzup.quiz.presentation;
 
-import com.greedy.zupzup.quiz.application.QuizService;
+import com.greedy.zupzup.quiz.application.QuizGenerationService;
+import com.greedy.zupzup.quiz.application.QuizSubmissionService;
 import com.greedy.zupzup.quiz.application.dto.QuizDto;
+import com.greedy.zupzup.quiz.application.dto.QuizResultDto;
+import com.greedy.zupzup.quiz.presentation.dto.QuizSubmissionRequest;
+import com.greedy.zupzup.quiz.presentation.dto.QuizSubmissionResponse;
 import com.greedy.zupzup.quiz.presentation.dto.QuizzesResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/lost-items/{lostItemId}/quizzes")
 @RequiredArgsConstructor
 public class QuizController {
 
-    private final QuizService quizService;
+    private final QuizGenerationService quizGenerationService;
+    private final QuizSubmissionService quizSubmissionService;
 
-    @GetMapping("/api/lost-items/{lostItemId}/quizzes")
-    public ResponseEntity<QuizzesResponse> generateLostItemQuizzes(
-            @PathVariable Long lostItemId,
-            Long memberId) {
-        List<QuizDto> quizDtos = quizService.generateLostItemQuizzes(lostItemId, memberId);
+    @GetMapping
+    public ResponseEntity<QuizzesResponse> generateLostItemQuizzes(@PathVariable Long lostItemId, Long memberId) {
+        List<QuizDto> quizDtos = quizGenerationService.generateLostItemQuizzes(lostItemId, memberId);
         return ResponseEntity.ok(QuizzesResponse.from(quizDtos));
+    }
+
+    @PostMapping
+    public ResponseEntity<QuizSubmissionResponse> submitQuizAnswers(@PathVariable Long lostItemId, Long memberId,
+            @Valid @RequestBody QuizSubmissionRequest submissionRequest) {
+        QuizResultDto resultDto = quizSubmissionService.submitQuizAnswers(lostItemId, memberId, submissionRequest.toCommands());
+        return ResponseEntity.ok(QuizSubmissionResponse.from(resultDto));
     }
 }

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/dto/AnswerRequest.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/dto/AnswerRequest.java
@@ -1,0 +1,13 @@
+package com.greedy.zupzup.quiz.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AnswerRequest(
+        @NotNull(message = "퀴즈의 특징을 선택해 주세요.")
+        Long featureId,
+
+        @NotNull(message = "퀴즈의 답변을 선택해 주세요.")
+        Long selectedOptionId
+) {
+
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/dto/LostItemDetailResponse.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/dto/LostItemDetailResponse.java
@@ -1,0 +1,13 @@
+package com.greedy.zupzup.quiz.presentation.dto;
+
+import com.greedy.zupzup.quiz.application.dto.LostItemDetailDto;
+
+public record LostItemDetailResponse(
+        String imageUrl,
+        String description
+) {
+
+    public static LostItemDetailResponse from(LostItemDetailDto detailDto) {
+        return new LostItemDetailResponse(detailDto.imageUrl(), detailDto.description());
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizOption.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizOption.java
@@ -1,0 +1,8 @@
+package com.greedy.zupzup.quiz.presentation.dto;
+
+public record QuizOption(
+        Long id,
+        String text
+) {
+
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizResponse.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizResponse.java
@@ -1,0 +1,19 @@
+package com.greedy.zupzup.quiz.presentation.dto;
+
+import com.greedy.zupzup.quiz.application.dto.QuizDto;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record QuizResponse(
+        Long featureId,
+        String question,
+        List<QuizOption> options
+) {
+
+    public static QuizResponse from(QuizDto quizDto) {
+        List<QuizOption> quizOptions = quizDto.options().stream()
+                .map(optionInfo -> new QuizOption(optionInfo.id(), optionInfo.text()))
+                .collect(Collectors.toList());
+        return new QuizResponse(quizDto.featureId(), quizDto.question(), quizOptions);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizSubmissionRequest.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizSubmissionRequest.java
@@ -1,10 +1,12 @@
 package com.greedy.zupzup.quiz.presentation.dto;
 
 import com.greedy.zupzup.quiz.application.dto.AnswerCommand;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public record QuizSubmissionRequest(
+        @NotEmpty(message = "퀴즈 답변을 하나 이상 제출해야 합니다.")
         List<AnswerRequest> answers
 ) {
 

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizSubmissionRequest.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizSubmissionRequest.java
@@ -1,0 +1,16 @@
+package com.greedy.zupzup.quiz.presentation.dto;
+
+import com.greedy.zupzup.quiz.application.dto.AnswerCommand;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record QuizSubmissionRequest(
+        List<AnswerRequest> answers
+) {
+
+    public List<AnswerCommand> toCommands() {
+        return answers.stream()
+                .map(AnswerCommand::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizSubmissionResponse.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizSubmissionResponse.java
@@ -1,0 +1,16 @@
+package com.greedy.zupzup.quiz.presentation.dto;
+
+import com.greedy.zupzup.quiz.application.dto.QuizResultDto;
+
+public record QuizSubmissionResponse(
+        boolean correct,
+        LostItemDetailResponse detail
+) {
+
+    public static QuizSubmissionResponse from(QuizResultDto resultDto) {
+        LostItemDetailResponse detailResponse = resultDto.detail() != null
+                ? LostItemDetailResponse.from(resultDto.detail())
+                : null;
+        return new QuizSubmissionResponse(resultDto.correct(), detailResponse);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizzesResponse.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/dto/QuizzesResponse.java
@@ -1,0 +1,17 @@
+package com.greedy.zupzup.quiz.presentation.dto;
+
+import com.greedy.zupzup.quiz.application.dto.QuizDto;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record QuizzesResponse (
+    List<QuizResponse> quizzes
+){
+
+    public static QuizzesResponse from(List<QuizDto> quizDtos) {
+        List<QuizResponse> quizzes = quizDtos.stream()
+                .map(QuizResponse::from)
+                .collect(Collectors.toList());
+        return new QuizzesResponse(quizzes);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
+++ b/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
@@ -1,6 +1,8 @@
 package com.greedy.zupzup.quiz.repository;
 
+import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.quiz.domain.QuizAttempt;
+import com.greedy.zupzup.quiz.exception.QuizException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +11,9 @@ public interface QuizAttemptRepository extends JpaRepository<QuizAttempt, Long> 
     boolean existsByLostItemIdAndMemberId(Long lostItemId, Long memberId);
 
     Optional<QuizAttempt> findByLostItemIdAndMemberId(Long lostItemId, Long memberId);
+
+    default QuizAttempt getByLostItemIdAndMemberId(Long lostItemId, Long memberId) {
+        return findByLostItemIdAndMemberId(lostItemId, memberId)
+                .orElseThrow(() -> new ApplicationException(QuizException.QUIZ_NOT_ATTEMPTED));
+    }
 }

--- a/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
+++ b/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
@@ -1,0 +1,9 @@
+package com.greedy.zupzup.quiz.repository;
+
+import com.greedy.zupzup.quiz.domain.QuizAttempt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizAttemptRepository extends JpaRepository<QuizAttempt, Long> {
+
+    boolean existsByLostItemIdAndMemberId(Long lostItemId, Long memberId);
+}

--- a/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
+++ b/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
@@ -1,9 +1,12 @@
 package com.greedy.zupzup.quiz.repository;
 
 import com.greedy.zupzup.quiz.domain.QuizAttempt;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizAttemptRepository extends JpaRepository<QuizAttempt, Long> {
 
     boolean existsByLostItemIdAndMemberId(Long lostItemId, Long memberId);
+
+    Optional<QuizAttempt> findByLostItemIdAndMemberId(Long lostItemId, Long memberId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,11 +4,11 @@ server:
 cloud:
   aws:
     credentials:
-      access-key: ${AWS_S3_ACCESS_KEY}
-      secret-key: ${AWS_S3_SECRET_ACCESS_KEY}
+      access-key: ${AWS_S3_ACCESS_KEY:S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_ACCESS_KEY:S3_SECRET_KEY}
     region:
       static: ap-northeast-2
     s3:
-      bucket: ${AWS_S3_BUCKET_NAME}
+      bucket: ${AWS_S3_BUCKET_NAME:s3-bucket}
       url:
-        prefix: "https://${AWS_S3_BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com"
+        prefix: "https://${AWS_S3_BUCKET_NAME:s3-bucket}.s3.ap-northeast-2.amazonaws.com"

--- a/src/test/java/com/greedy/zupzup/ZupzupApplicationTests.java
+++ b/src/test/java/com/greedy/zupzup/ZupzupApplicationTests.java
@@ -2,7 +2,9 @@ package com.greedy.zupzup;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ZupzupApplicationTests {
 

--- a/src/test/java/com/greedy/zupzup/common/ControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/common/ControllerTest.java
@@ -1,0 +1,52 @@
+package com.greedy.zupzup.common;
+
+import com.greedy.zupzup.category.repository.CategoryRepository;
+import com.greedy.zupzup.category.repository.FeatureOptionRepository;
+import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
+import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemRepository;
+import com.greedy.zupzup.schoolarea.repository.SchoolAreaRepository;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql("/truncate.sql")
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class ControllerTest {
+
+    @MockitoBean
+    protected S3ImageFileManager imageFileManager;
+
+    @Autowired
+    protected LostItemRepository lostItemRepository;
+
+    @Autowired
+    protected LostItemFeatureRepository lostItemFeatureRepository;
+
+    @Autowired
+    protected LostItemImageRepository lostItemImageRepository;
+
+    @Autowired
+    protected CategoryRepository categoryRepository;
+
+    @Autowired
+    protected FeatureOptionRepository featureOptionRepository;
+
+    @Autowired
+    protected SchoolAreaRepository schoolAreaRepository;
+
+    @LocalServerPort
+    protected int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+}

--- a/src/test/java/com/greedy/zupzup/common/ServiceUnitTest.java
+++ b/src/test/java/com/greedy/zupzup/common/ServiceUnitTest.java
@@ -1,0 +1,38 @@
+package com.greedy.zupzup.common;
+
+import com.greedy.zupzup.category.repository.CategoryRepository;
+import com.greedy.zupzup.category.repository.FeatureOptionRepository;
+import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
+import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemRepository;
+import com.greedy.zupzup.schoolarea.repository.SchoolAreaRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class ServiceUnitTest {
+
+    @Mock
+    protected LostItemRepository lostItemRepository;
+
+    @Mock
+    protected LostItemImageRepository lostItemImageRepository;
+
+    @Mock
+    protected LostItemFeatureRepository lostItemFeatureRepository;
+
+    @Mock
+    protected FeatureOptionRepository featureOptionRepository;
+
+    @Mock
+    protected SchoolAreaRepository schoolAreaRepository;
+
+    @Mock
+    protected CategoryRepository categoryRepository;
+
+    @Mock
+    protected S3ImageFileManager s3ImageFileManager;
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+
+  datasource:
+    url: jdbc:mysql://localhost:3307/zupzup_test_db
+    username: root
+    password: test135
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+logging:
+  level:
+    org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl: error
+    org.hibernate.SQL: debug

--- a/src/test/resources/truncate.sql
+++ b/src/test/resources/truncate.sql
@@ -1,0 +1,11 @@
+set FOREIGN_KEY_CHECKS = 0;
+
+truncate table keyword_alert;
+truncate table member;
+truncate table pledge;
+truncate table quiz_attempt;
+truncate table lost_item;
+truncate table lost_item_feature;
+truncate table lost_item_image;
+
+set FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
closed #13

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- GET /api/lost-items/{lost_item_id}/quizzes
    - 분실물에 대한 퀴즈 정보를 가져오는 API를 구현했습니다.
     
- POST /api/lost-items/{lost_item_id}/quizzes
    - 사용자가 제출한 퀴즈 정답 여부를 확인하고 정답일 경우엔 분실물의 상세 정보를 반환하는 API를 구현했습니다.

- POST /api/lost-items/{lost_item_id}/pledge
    - 사용자의 서약 정보를 받아 분실물의 상태를 변경하고, 보관 장소를 반환하는 API를 구현했습니다. 
## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  
코드를 짜다보니 좀 복잡해진 것 같아서 혹시 이해가 안되거나 더 좋은 구조/리팩토링 할 부분이 있다면 조언 부탁드립니다. 또 제가 놓치고 있는 처리들이 있는지 검토해주시면 감사하겠습니다:)

## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->

## ✅ 테스트
- [X] 수동 테스트 완료
- [ ] 테스트 코드 완료
