### PR TITLE
test: 학교 구역 조회 기능 테스트 작성

### DIFF
--- a/src/test/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerTest.java
@@ -1,12 +1,19 @@
 package com.greedy.zupzup.schoolarea.presentation;
 
 import com.greedy.zupzup.common.ControllerTest;
+import com.greedy.zupzup.global.exception.CommonException;
+import com.greedy.zupzup.global.exception.ErrorResponse;
+import com.greedy.zupzup.schoolarea.exception.SchoolAreaException;
 import com.greedy.zupzup.schoolarea.presentation.dto.AllSchoolAreasResponse;
+import com.greedy.zupzup.schoolarea.presentation.dto.SchoolAreaResponse;
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class SchoolAreaControllerTest extends ControllerTest {
 
@@ -27,5 +34,112 @@ class SchoolAreaControllerTest extends ControllerTest {
         assertThat(response.count()).isEqualTo(3);
     }
 
+    @Test
+    void 위도_경도_좌표가_주어지면_해당_좌표가_속한_학교_구역을_응답해야_한다() {
 
+        // given
+        Double lat = 37.55121049168251;
+        Double lng = 127.0745588999;
+
+        // when
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .param("lat", String.valueOf(lat))
+                .param("lng", String.valueOf(lng))
+                .when()
+                .get("/api/school-areas/contains")
+                .then().log().all()
+                .extract();
+
+        // then
+        int statusCode = extract.statusCode();
+        SchoolAreaResponse response = extract.as(SchoolAreaResponse.class);
+
+        assertSoftly(softly -> {
+            softly.assertThat(statusCode).isEqualTo(200);
+            softly.assertThat(response.id()).isEqualTo(2L);
+            softly.assertThat(response.areaName()).isEqualTo("세종대학교 운동장 옆 길");
+        });
+    }
+
+    @Test
+    void 주어진_위도_경도_좌표가_속한_학교_구역이_존재하지_않는다면_오류를_응답해야_한다() {
+
+        // given
+        Double lat = 0.0;
+        Double lng = 0.0;
+
+        // when
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .param("lat", String.valueOf(lat))
+                .param("lng", String.valueOf(lng))
+                .when()
+                .get("/api/school-areas/contains")
+                .then().log().all()
+                .extract();
+
+        // then
+        int statusCode = extract.statusCode();
+        ErrorResponse response = extract.as(ErrorResponse.class);
+        assertSoftly(softly -> {
+            softly.assertThat(statusCode).isEqualTo(400);
+            softly.assertThat(response.status()).isEqualTo(SchoolAreaException.SCHOOL_AREA_OUT_OF_BOUND.getHttpStatus().value());
+            softly.assertThat(response.title()).isEqualTo(SchoolAreaException.SCHOOL_AREA_OUT_OF_BOUND.getTitle());
+            softly.assertThat(response.detail()).isEqualTo(SchoolAreaException.SCHOOL_AREA_OUT_OF_BOUND.getDetail());
+            softly.assertThat(response.instance()).isEqualTo("/api/school-areas/contains");
+        });
+    }
+
+    @Test
+    void 주어진_위도_경도의_범위가_유효하지_않다면_오류를_응답해야_한다() {
+
+        // given - 위도는 -90 ~ 90 | 경도는 -180 ~ 180 이어야 한다.
+        Double lat = 100.0;
+        Double lng = -200.0;
+
+        // when
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .param("lat", String.valueOf(lat))
+                .param("lng", String.valueOf(lng))
+                .when()
+                .get("/api/school-areas/contains")
+                .then().log().all()
+                .extract();
+
+        // then
+        int statusCode = extract.statusCode();
+        ErrorResponse response = extract.as(ErrorResponse.class);
+        assertSoftly(softly -> {
+            softly.assertThat(statusCode).isEqualTo(400);
+            softly.assertThat(response.status()).isEqualTo(CommonException.INVALID_INPUT_VALUE.getHttpStatus().value());
+            softly.assertThat(response.title()).isEqualTo(CommonException.INVALID_INPUT_VALUE.getTitle());
+            softly.assertThat(response.detail()).contains("경도는 -180 이상이어야 합니다.");
+            softly.assertThat(response.detail()).contains("위도는 90 이하여야 합니다.");
+            softly.assertThat(response.instance()).isEqualTo("/api/school-areas/contains");
+        });
+    }
+
+    @Test
+    void 위도_경도의_값이_주어지지_않는_다면_오류를_응답해야_한다() {
+
+        // given & when
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/api/school-areas/contains")
+                .then().log().all()
+                .extract();
+
+        // then
+        int statusCode = extract.statusCode();
+        ErrorResponse response = extract.as(ErrorResponse.class);
+        assertSoftly(softly -> {
+            softly.assertThat(statusCode).isEqualTo(400);
+            softly.assertThat(response.status()).isEqualTo(CommonException.INVALID_INPUT_VALUE.getHttpStatus().value());
+            softly.assertThat(response.title()).isEqualTo(CommonException.INVALID_INPUT_VALUE.getTitle());
+            softly.assertThat(response.instance()).isEqualTo("/api/school-areas/contains");
+        });
+    }
 }

--- a/src/test/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerTest.java
@@ -1,0 +1,31 @@
+package com.greedy.zupzup.schoolarea.presentation;
+
+import com.greedy.zupzup.common.ControllerTest;
+import com.greedy.zupzup.schoolarea.presentation.dto.AllSchoolAreasResponse;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.*;
+
+class SchoolAreaControllerTest extends ControllerTest {
+
+    @Test
+    void 모든_학교_구역을_응답해야한다() {
+
+        // given & when
+        AllSchoolAreasResponse response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/api/school-areas")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(AllSchoolAreasResponse.class);
+
+        // then
+        assertThat(response.count()).isEqualTo(3);
+    }
+
+
+}


### PR DESCRIPTION
## 📎 Issue 번호
- close: #24 

## ✨ 작업 내용
- `SchoolArea 도메인`에 해당하는 기능들에 대한 테스트 작성
- 전체 학교 구역을 조회하는 API 인수 테스트 작성
- 좌표로 학교 구역을 조회하는 API 인수 테스트 작성

SchoolArea의 서비스 레이어에는 별다른 로직이 없기 떄문에, (단순히 Repositoy의 메서드만 호출하고 컨트롤러에 전달하기에)
서비스 레이어의 단위테스트는 진행하지 않고, API의 인수 테스트(통합 테스트)만 진행했습니다!

## 🎯 리뷰 포인트
- 일단은 컨벤션이 아직 안 정해졌기 때문에, 제 스타일 대로 테스트 코드를 짜 보았는데요,
- 테스트 코드를 짜는 컨벤션에 대해서는 이 PR 에서 이야기를 나누어 보면서 정해 보도록 해요~~
  (예를들어, 테스트 메서드에 한글로 이름을 지을지, `@DisplayName` 을 사용할지... 등등)

## 📝 기타
- `given-when-then` 절로 테스트를 나누어서 작성을 했는데요, 이 부분은 개인적으로 팀 컨벤션으로 가져가는 게 좋을 것 같아요!!
- 가독성이 좋아지고, 테스트 의도가 명확해져서 테스트를 짤 때나, 코드를 이해하는데에도 큰 도움이 될 것 같아요.

[given-when-then 참고 자료](https://brunch.co.kr/@springboot/292)

## ✅ 테스트
- [x] 수동 테스트 완료
- [x] 테스트 코드 완료
