### PR TITLE
feat: API 문서화를 위한 Swagger 도입 #23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.4'
+	id 'org.springframework.boot' version '3.3.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -39,6 +39,7 @@ dependencies {
 
 	implementation 'software.amazon.awssdk:s3:2.25.11'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/greedy/zupzup/global/infrastructure/SwaggerConfig.java
+++ b/src/main/java/com/greedy/zupzup/global/infrastructure/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.greedy.zupzup.global.infrastructure;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("\uD83D\uDCF7ZupZup")
+                .description("""
+                        ### 줍줍(Zupzup)
+                        #### [Github](https://github.com/greedy-team/zup-zup-be.git)""")
+                .version("v1.0.0");
+
+        String jwtSchemeName = "Bearer Token";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/pledge/presentation/PledgeController.java
+++ b/src/main/java/com/greedy/zupzup/pledge/presentation/PledgeController.java
@@ -9,19 +9,21 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/lost-items/{lostItemId}/pledge")
 @RequiredArgsConstructor
-public class PledgeController {
+public class PledgeController implements PledgeControllerDocs{
 
     private final PledgeService pledgeService;
 
+    @Override
     @PostMapping
     public ResponseEntity<PledgeResponse> createPledge(
             @PathVariable Long lostItemId,
-            Long memberId
+            @RequestParam Long memberId
     ) {
         Pledge pledge = pledgeService.createPledge(lostItemId, memberId);
         return ResponseEntity

--- a/src/main/java/com/greedy/zupzup/pledge/presentation/PledgeControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/pledge/presentation/PledgeControllerDocs.java
@@ -1,0 +1,30 @@
+package com.greedy.zupzup.pledge.presentation;
+
+import com.greedy.zupzup.pledge.presentation.dto.PledgeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name="Pledge", description = "분실물 찾기 서약 관련 API")
+public interface PledgeControllerDocs {
+
+    @Operation(summary = "분실물 습득 서약 생성",
+            description = "사용자가 분실물을 찾기 전 악용 방지를 위해 서약을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "서약 생성 성공"),
+            @ApiResponse(responseCode = "404", description = "요청한 분실물을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 서약이 완료되어 처리할 수 없음")
+    })
+    ResponseEntity<PledgeResponse> createPledge(
+            @Parameter(description = "서약할 분실물", required = true, example = "12")
+            @PathVariable Long lostItemId,
+
+            @Parameter(description = "서약하는 사용자", required = true, example = "1")
+            @RequestParam Long memberId
+    );
+}

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/QuizController.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/QuizController.java
@@ -21,17 +21,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/lost-items/{lostItemId}/quizzes")
 @RequiredArgsConstructor
-public class QuizController {
+public class QuizController implements QuizControllerDocs{
 
     private final QuizGenerationService quizGenerationService;
     private final QuizSubmissionService quizSubmissionService;
 
+    @Override
     @GetMapping
     public ResponseEntity<QuizzesResponse> getLostItemQuizzes(@PathVariable Long lostItemId, Long memberId) {
         List<QuizDto> quizDtos = quizGenerationService.getLostItemQuizzes(lostItemId, memberId);
         return ResponseEntity.ok(QuizzesResponse.from(quizDtos));
     }
 
+    @Override
     @PostMapping
     public ResponseEntity<QuizSubmissionResponse> submitQuizAnswers(@PathVariable Long lostItemId, Long memberId,
             @Valid @RequestBody QuizSubmissionRequest submissionRequest) {

--- a/src/main/java/com/greedy/zupzup/quiz/presentation/QuizControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/quiz/presentation/QuizControllerDocs.java
@@ -1,0 +1,113 @@
+package com.greedy.zupzup.quiz.presentation;
+
+import com.greedy.zupzup.quiz.presentation.dto.QuizSubmissionRequest;
+import com.greedy.zupzup.quiz.presentation.dto.QuizSubmissionResponse;
+import com.greedy.zupzup.quiz.presentation.dto.QuizzesResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Quiz", description = "분실물 주인 확인 퀴즈 관련 API")
+public interface QuizControllerDocs {
+
+    @Operation(
+            summary = "분실물 퀴즈 조회",
+            description = """
+            특정 분실물의 주인을 판별하기 위한 퀴즈 목록을 조회합니다.
+
+            ### 요청 예시
+            GET /quizzes/{lostItemId}?memberId=1
+
+            ### 응답 예시
+            ```json
+            {
+              "quizzes": [
+                {
+                  "featureId": 1,
+                  "question": "어떤 브랜드의 제품인가요?",
+                  "options": [
+                    { "id": 1, "text": "삼성" },
+                    { "id": 3, "text": "LG" },
+                    { "id": 2, "text": "애플" },
+                    { "id": 4, "text": "기타" }
+                  ]
+                },
+                {
+                  "featureId": 2,
+                  "question": "제품의 색상은 무엇인가요?",
+                  "options": [
+                    { "id": 8, "text": "골드" },
+                    { "id": 5, "text": "블랙" },
+                    { "id": 7, "text": "실버" },
+                    { "id": 9, "text": "기타" }
+                  ]
+                }
+              ]
+            }
+            ```
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "퀴즈 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "요청한 분실물을 찾을 수 없음"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터")
+    })
+    ResponseEntity<QuizzesResponse> getLostItemQuizzes(
+            @Parameter(description = "퀴즈를 조회할 분실물", required = true, example = "101")
+            @PathVariable Long lostItemId,
+            @Parameter(description = "퀴즈를 푸는 사용자", required = true, example = "7")
+            @RequestParam Long memberId
+    );
+
+    @Operation(
+            summary = "퀴즈 정답 제출 및 채점",
+            description = """
+            사용자가 제출한 퀴즈 답안을 채점하고 정답 여부를 반환합니다.
+
+            ### 요청 본문 예시
+            ```json
+            {
+              "answers": [
+                { "featureId": 1, "selectedOptionId": 2 },
+                { "featureId": 2, "selectedOptionId": 5 }
+              ]
+            }
+            ```
+
+            ### 응답 예시
+            - 정답:
+            ```json
+            {
+              "correct": true,
+              "detail": {
+                "imageUrl": "https://zupzup-static-files.s3.ap-northeast-2.amazonaws.com/dev/iphone.webp",
+                "description": "검정색 아이폰 15 프로입니다. 케이스는 투명색입니다."
+              }
+            }
+            ```
+            - 오답:
+            ```json
+            { "correct": false }
+            ```
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채점 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 형식 오류 (예: answers 배열 비어있음)"),
+            @ApiResponse(responseCode = "404", description = "요청한 분실물을 찾을 수 없음")
+    })
+    ResponseEntity<QuizSubmissionResponse> submitQuizAnswers(
+            @Parameter(description = "채점할 분실물", required = true, example = "101")
+            @PathVariable Long lostItemId,
+            @Parameter(description = "퀴즈를 푸는 사용자", required = true, example = "7")
+            @RequestParam Long memberId,
+            @Valid @RequestBody QuizSubmissionRequest submissionRequest
+    );
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,11 +4,18 @@ server:
 cloud:
   aws:
     credentials:
-      access-key: ${AWS_S3_ACCESS_KEY:S3_ACCESS_KEY}
-      secret-key: ${AWS_S3_SECRET_ACCESS_KEY:S3_SECRET_KEY}
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_ACCESS_KEY}
     region:
       static: ap-northeast-2
     s3:
-      bucket: ${AWS_S3_BUCKET_NAME:s3-bucket}
+      bucket: ${AWS_S3_BUCKET_NAME}
       url:
-        prefix: "https://${AWS_S3_BUCKET_NAME:s3-bucket}.s3.ap-northeast-2.amazonaws.com"
+        prefix: "https://${AWS_S3_BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com"
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui.display-request-duration: true
+  swagger-ui:
+    path: /docs/swagger


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
closed #20

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
Swagger(OpenAPI)를 이용한 API 문서화 도입
- GET /api/lost-items/{lost_item_id}/quizzes     
- POST /api/lost-items/{lost_item_id}/quizzes
- POST /api/lost-items/{lost_item_id}/pledge
이 세 API의 문서화를 진행했고 여러분들이 맡은 api별로 만들어주시면 될 것 같아요!

## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  
docs 인터페이스로 API 명세를 분리하는 구조를 적용했습니다. docs에서 현재 문서화 스타일에서 더 깔끔하고 가독성 좋은 방법이 있다면 자유롭게 의견 부탁드립니다:) 

## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->

## ✅ 테스트
- [X] 수동 테스트 완료
- [ ] 테스트 코드 완료
