### PR TITLE
feat: 분실물 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/greedy/zupzup/global/exception/CommonException.java
+++ b/src/main/java/com/greedy/zupzup/global/exception/CommonException.java
@@ -19,7 +19,9 @@ public enum CommonException implements ExceptionCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력값", "입력값이 유효성 검사를 통과하지 못했습니다."),
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 미디어 타입", "서버에서 지원하지 않는 Content-Type 입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드", "해당 엔드 포인트는 서버에서 지원하지 않는 HTTP 메소드 입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류", "서버 내부에 알 수 없는 오류가 발생했습니다. 관리자에게 문의 하세요.")
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류", "서버 내부에 알 수 없는 오류가 발생했습니다. 관리자에게 문의 하세요."),
+    ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 제한되었습니다.", "해당 분실물의 보관 정보는 열람 권한이 없습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemDetailViewService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemDetailViewService.java
@@ -1,0 +1,70 @@
+package com.greedy.zupzup.lostitem.application;
+
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.global.exception.CommonException;
+import com.greedy.zupzup.lostitem.application.dto.LostItemDetailViewCommand;
+import com.greedy.zupzup.lostitem.domain.LostItem;
+import com.greedy.zupzup.lostitem.domain.LostItemImage;
+import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
+import com.greedy.zupzup.lostitem.repository.LostItemRepository;
+import com.greedy.zupzup.member.repository.MemberRepository;
+import com.greedy.zupzup.pledge.repository.PledgeRepository;
+import com.greedy.zupzup.quiz.domain.QuizAttempt;
+import com.greedy.zupzup.quiz.repository.QuizAttemptRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LostItemDetailViewService {
+
+    private final LostItemRepository lostItemRepository;
+    private final LostItemImageRepository imageRepository;
+    private final MemberRepository memberRepository;
+    private final PledgeRepository pledgeRepository;
+    private final QuizAttemptRepository quizAttemptRepository;
+
+    @Transactional(readOnly = true)
+    public LostItemDetailViewCommand getDetail(Long lostItemId, Long memberId) {
+        memberRepository.getById(memberId);
+
+        LostItem li = lostItemRepository.getWithCategoryAndAreaById(lostItemId);
+
+        boolean quizRequired = !li.isNotQuizCategory();
+        boolean pledgedByMe = pledgeRepository.existsByLostItem_IdAndOwner_Id(li.getId(), memberId);
+        boolean quizAnswered = quizAttemptRepository
+                .findByLostItemIdAndMemberId(li.getId(), memberId)
+                .map(QuizAttempt::getIsCorrect)
+                .orElse(false);
+
+        if (quizRequired && !pledgedByMe) {
+            throw new ApplicationException(CommonException.ACCESS_FORBIDDEN);
+        }
+
+        List<String> imageUrls = imageRepository.findAllByLostItemIdOrderByImageOrder(li.getId())
+                .stream()
+                .map(LostItemImage::getImageKey)
+                .toList();
+
+        return new LostItemDetailViewCommand(
+                li.getId(),
+                li.getStatus(),
+                li.getCategory().getId(),
+                li.getCategory().getName(),
+                li.getCategory().getIconUrl(),
+                li.getFoundArea().getId(),
+                li.getFoundArea().getAreaName(),
+                li.getFoundAreaDetail(),
+                li.getDescription(),
+                imageUrls,
+                li.getDepositArea(),
+                li.getPledgedAt(),
+                li.getCreatedAt(),
+                quizRequired,
+                quizAnswered,
+                pledgedByMe
+        );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemListService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemListService.java
@@ -1,6 +1,6 @@
 package com.greedy.zupzup.lostitem.application;
 
-import com.greedy.zupzup.lostitem.LostItemStatus;
+import com.greedy.zupzup.lostitem.domain.LostItemStatus;
 import com.greedy.zupzup.lostitem.application.dto.LostItemListCommand;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;

--- a/src/main/java/com/greedy/zupzup/lostitem/application/dto/LostItemDetailViewCommand.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/dto/LostItemDetailViewCommand.java
@@ -1,5 +1,6 @@
 package com.greedy.zupzup.lostitem.application.dto;
 
+import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -23,4 +24,29 @@ public record LostItemDetailViewCommand(
         boolean quizAnswered,
         boolean pledgedByMe
 ) {
+    public static LostItemDetailViewCommand of(LostItem item,
+                                               List<String> imageUrls,
+                                               String depositArea,
+                                               boolean quizRequired,
+                                               boolean quizAnswered,
+                                               boolean pledgedByMe) {
+        return new LostItemDetailViewCommand(
+                item.getId(),
+                item.getStatus(),
+                item.getCategory().getId(),
+                item.getCategory().getName(),
+                item.getCategory().getIconUrl(),
+                item.getFoundArea().getId(),
+                item.getFoundArea().getAreaName(),
+                item.getFoundAreaDetail(),
+                item.getDescription(),
+                imageUrls,
+                depositArea,
+                item.getPledgedAt(),
+                item.getCreatedAt(),
+                quizRequired,
+                quizAnswered,
+                pledgedByMe
+        );
+    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/application/dto/LostItemDetailViewCommand.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/dto/LostItemDetailViewCommand.java
@@ -1,0 +1,26 @@
+package com.greedy.zupzup.lostitem.application.dto;
+
+import com.greedy.zupzup.lostitem.domain.LostItemStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record LostItemDetailViewCommand(
+        Long id,
+        LostItemStatus status,
+        Long categoryId,
+        String categoryName,
+        String categoryIconUrl,
+        Long schoolAreaId,
+        String schoolAreaName,
+        String locationDetail,
+        String description,
+        List<String> imageUrls,
+        String depositArea,
+        LocalDate pledgedAt,
+        LocalDateTime createdAt,
+        boolean quizRequired,
+        boolean quizAnswered,
+        boolean pledgedByMe
+) {
+}

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemDetailViewController.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemDetailViewController.java
@@ -1,0 +1,27 @@
+package com.greedy.zupzup.lostitem.presentation;
+
+import com.greedy.zupzup.lostitem.application.LostItemDetailViewService;
+import com.greedy.zupzup.lostitem.presentation.dto.LostItemDetailViewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lost-items")
+public class LostItemDetailViewController {
+
+    private final LostItemDetailViewService service;
+
+    @GetMapping("/{lostItemId}")
+    public ResponseEntity<LostItemDetailViewResponse> getDetail(@PathVariable Long lostItemId,
+                                                                @RequestParam Long memberId) {
+        return ResponseEntity.ok(
+                LostItemDetailViewResponse.from(service.getDetail(lostItemId, memberId))
+        );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemDetailViewController.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemDetailViewController.java
@@ -1,6 +1,7 @@
 package com.greedy.zupzup.lostitem.presentation;
 
 import com.greedy.zupzup.lostitem.application.LostItemDetailViewService;
+import com.greedy.zupzup.lostitem.application.dto.LostItemDetailViewCommand;
 import com.greedy.zupzup.lostitem.presentation.dto.LostItemDetailViewResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,8 +21,7 @@ public class LostItemDetailViewController {
     @GetMapping("/{lostItemId}")
     public ResponseEntity<LostItemDetailViewResponse> getDetail(@PathVariable Long lostItemId,
                                                                 @RequestParam Long memberId) {
-        return ResponseEntity.ok(
-                LostItemDetailViewResponse.from(service.getDetail(lostItemId, memberId))
-        );
+        LostItemDetailViewCommand cmd = service.getDetail(lostItemId, memberId);
+        return ResponseEntity.ok(LostItemDetailViewResponse.from(cmd));
     }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/dto/LostItemDetailViewResponse.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/dto/LostItemDetailViewResponse.java
@@ -1,0 +1,55 @@
+package com.greedy.zupzup.lostitem.presentation.dto;
+
+import com.greedy.zupzup.lostitem.application.dto.LostItemDetailViewCommand;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public record LostItemDetailViewResponse(
+        Long id,
+        String status,
+        Category category,
+        SchoolArea schoolArea,
+        String locationDetail,
+        String description,
+        List<String> imageKeys,
+        String depositArea,
+        String pledgedAt,
+        String createdAt,
+        boolean quizRequired,
+        boolean quizAnswered,
+        boolean pledgedByMe
+) {
+
+    public static LostItemDetailViewResponse from(LostItemDetailViewCommand c) {
+
+        String createdAt = c.createdAt()
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        String pledgedAt = c.pledgedAt() == null ? null
+                : c.pledgedAt().toString();
+
+        return new LostItemDetailViewResponse(
+                c.id(),
+                c.status().name(),
+                new Category(c.categoryId(), c.categoryName(), c.categoryIconUrl()),
+                new SchoolArea(c.schoolAreaId(), c.schoolAreaName()),
+                c.locationDetail(),
+                c.description(),
+                c.imageUrls(),
+                c.depositArea(),
+                pledgedAt,
+                createdAt,
+                c.quizRequired(),
+                c.quizAnswered(),
+                c.pledgedByMe()
+        );
+    }
+
+    public record Category(Long id, String name, String iconUrl) {
+    }
+
+    public record SchoolArea(Long id, String name) {
+    }
+}

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/dto/LostItemDetailViewResponse.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/dto/LostItemDetailViewResponse.java
@@ -12,7 +12,7 @@ public record LostItemDetailViewResponse(
         SchoolArea schoolArea,
         String locationDetail,
         String description,
-        List<String> imageKeys,
+        List<String> imageUrls,
         String depositArea,
         String pledgedAt,
         String createdAt,
@@ -21,29 +21,29 @@ public record LostItemDetailViewResponse(
         boolean pledgedByMe
 ) {
 
-    public static LostItemDetailViewResponse from(LostItemDetailViewCommand c) {
+    public static LostItemDetailViewResponse from(LostItemDetailViewCommand command) {
 
-        String createdAt = c.createdAt()
+        String createdAt = command.createdAt()
                 .atZone(ZoneId.of("Asia/Seoul"))
                 .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 
-        String pledgedAt = c.pledgedAt() == null ? null
-                : c.pledgedAt().toString();
+        String pledgedAt = command.pledgedAt() == null ? null
+                : command.pledgedAt().toString();
 
         return new LostItemDetailViewResponse(
-                c.id(),
-                c.status().name(),
-                new Category(c.categoryId(), c.categoryName(), c.categoryIconUrl()),
-                new SchoolArea(c.schoolAreaId(), c.schoolAreaName()),
-                c.locationDetail(),
-                c.description(),
-                c.imageUrls(),
-                c.depositArea(),
+                command.id(),
+                command.status().name(),
+                new Category(command.categoryId(), command.categoryName(), command.categoryIconUrl()),
+                new SchoolArea(command.schoolAreaId(), command.schoolAreaName()),
+                command.locationDetail(),
+                command.description(),
+                command.imageUrls(),
+                command.depositArea(),
                 pledgedAt,
                 createdAt,
-                c.quizRequired(),
-                c.quizAnswered(),
-                c.pledgedByMe()
+                command.quizRequired(),
+                command.quizAnswered(),
+                command.pledgedByMe()
         );
     }
 

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemImageRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemImageRepository.java
@@ -17,10 +17,10 @@ public interface LostItemImageRepository extends JpaRepository<LostItemImage, Lo
     List<RepresentativeImageProjection> findRepresentativeImages(@Param("ids") Collection<Long> ids);
 
     @Query("""
-                select i
+                select i.imageKey
                   from LostItemImage i
                  where i.lostItem.id = :lostItemId
                  order by i.imageOrder asc
             """)
-    List<LostItemImage> findAllByLostItemIdOrderByImageOrder(@Param("lostItemId") Long lostItemId);
+    List<String> findImageUrlsByLostItemId(@Param("lostItemId") Long lostItemId);
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemImageRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemImageRepository.java
@@ -15,4 +15,12 @@ public interface LostItemImageRepository extends JpaRepository<LostItemImage, Lo
             where i.imageOrder = 0 and i.lostItem.id in :ids
             """)
     List<RepresentativeImageProjection> findRepresentativeImages(@Param("ids") Collection<Long> ids);
+
+    @Query("""
+                select i
+                  from LostItemImage i
+                 where i.lostItem.id = :lostItemId
+                 order by i.imageOrder asc
+            """)
+    List<LostItemImage> findAllByLostItemIdOrderByImageOrder(@Param("lostItemId") Long lostItemId);
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemRepository.java
@@ -65,4 +65,18 @@ public interface LostItemRepository extends JpaRepository<LostItem, Long> {
         return findWithCategoryById(id)
                 .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
     }
+
+    @Query("""
+        select li
+          from LostItem li
+          join fetch li.category c
+          join fetch li.foundArea sa
+         where li.id = :id
+    """)
+    Optional<LostItem> findWithCategoryAndAreaById(@Param("id") Long id);
+
+    default LostItem getWithCategoryAndAreaById(Long id) {
+        return findWithCategoryAndAreaById(id)
+                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemSummaryRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemSummaryRepository.java
@@ -23,7 +23,7 @@ public interface LostItemSummaryRepository extends Repository<LostItemSummaryPro
             from SchoolArea sa
                 left join LostItem li
                     on li.foundArea.id = sa.id
-                   and li.status = com.greedy.zupzup.lostitem.LostItemStatus.REGISTERED
+                   and li.status = com.greedy.zupzup.lostitem.domain.LostItemStatus.REGISTERED
                    and (:categoryId is null or li.category.id = :categoryId)
             group by sa.id, sa.areaName
             """

--- a/src/main/java/com/greedy/zupzup/pledge/repository/PledgeRepository.java
+++ b/src/main/java/com/greedy/zupzup/pledge/repository/PledgeRepository.java
@@ -4,5 +4,5 @@ import com.greedy.zupzup.pledge.domain.Pledge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PledgeRepository extends JpaRepository<Pledge, Long> {
-
+    boolean existsByLostItem_IdAndOwner_Id(Long lostItemId, Long ownerId);
 }


### PR DESCRIPTION
## 📎 Issue 번호  
closed #18

## ✨ 작업 내용
분실물의 상세정보를 응답하는 API

-귀중품일 경우 서약한 회원만 상세 정보 열람 가능
-비 귀중품일 경우 모든 회원이 상세 정보 열람 가능
## 🎯 리뷰 포인트
놓친 구현 포인트나 더 나은 구조가 있다면 피드백 주시면 감사하겠습니다!!

## ✅ 테스트
- [X] 수동 테스트 완료
- [ ] 테스트 코드 완료
