### PR TITLE
feat: 로그인 기능 개발 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'
 
+	// 비밀번호 암호와
+	implementation 'org.mindrot:jbcrypt:0.4'
+
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,10 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.3'
 	implementation 'org.jsoup:jsoup:1.15.3'
 
-
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,14 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3:2.25.11'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// 포털 로그인 위한 의존성
+	implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+	implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.3'
+	implementation 'org.jsoup:jsoup:1.15.3'
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/greedy/zupzup/DataLoader.java
+++ b/src/main/java/com/greedy/zupzup/DataLoader.java
@@ -83,32 +83,7 @@ public class DataLoader implements CommandLineRunner {
             log.info("구역 정보가 이미 존재하여 초기화를 건너뜁니다.");
         }
     }
-
-    private List<SchoolArea> createSchoolAreas() {
-        Polygon playground = geometryFactory.createPolygon(new Coordinate[]{
-                new Coordinate(127.0752831, 37.5510817), new Coordinate(127.0742638, 37.5502523),
-                new Coordinate(127.0749505, 37.5498356), new Coordinate(127.0759912, 37.5507372),
-                new Coordinate(127.0752831, 37.5510817)
-        });
-        SchoolArea playgroundZone = new SchoolArea("세종대학교 운동장", playground);
-
-        Polygon sideRoad = geometryFactory.createPolygon(new Coordinate[]{
-                new Coordinate(127.0738508, 37.5506351), new Coordinate(127.0742638, 37.5502523),
-                new Coordinate(127.075326, 37.5511285), new Coordinate(127.0747198, 37.5516133),
-                new Coordinate(127.0740868, 37.5510902), new Coordinate(127.0739902, 37.5510051),
-                new Coordinate(127.0741565, 37.5508605), new Coordinate(127.0738508, 37.5506351)
-        });
-        SchoolArea sideRoadZone = new SchoolArea("세종대학교 운동장 옆 길", sideRoad);
-
-        Polygon aiCenter = geometryFactory.createPolygon(new Coordinate[]{
-                new Coordinate(127.0754923, 37.551137), new Coordinate(127.0757605, 37.5508988),
-                new Coordinate(127.076018, 37.5510647), new Coordinate(127.0757015, 37.5512986),
-                new Coordinate(127.0754923, 37.551137)
-        });
-        SchoolArea aiCenterZone = new SchoolArea("세종대학교 AI 센터", aiCenter);
-
-        return schoolAreaRepository.saveAll(Arrays.asList(playgroundZone, sideRoadZone, aiCenterZone));
-    }
+    
 
     private void initCategoryData() {
         log.info("카테고리 정보를 초기화합니다.");

--- a/src/main/java/com/greedy/zupzup/DataLoader.java
+++ b/src/main/java/com/greedy/zupzup/DataLoader.java
@@ -12,7 +12,6 @@ import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.member.domain.Member;
-import com.greedy.zupzup.member.domain.Provider;
 import com.greedy.zupzup.member.domain.Role;
 import com.greedy.zupzup.member.repository.MemberRepository;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
@@ -149,12 +148,9 @@ public class DataLoader implements CommandLineRunner {
         log.info("회원 정보를 초기화합니다.");
         if (memberRepository.count() == 0) {
             Member member = Member.builder()
-                    .email("testuser@example.com")
-                    .nickname("테스트유저")
-                    .provider(Provider.GOOGLE)
-                    .providerId("123456789")
+                    .name("테스트유저")
+                    .studentId("123456789")
                     .role(Role.USER)
-                    .emailConsent(true)
                     .build();
             memberRepository.save(member);
             log.info("임시 회원 정보 초기화 완료!");

--- a/src/main/java/com/greedy/zupzup/DataLoader.java
+++ b/src/main/java/com/greedy/zupzup/DataLoader.java
@@ -149,7 +149,7 @@ public class DataLoader implements CommandLineRunner {
         if (memberRepository.count() == 0) {
             Member member = Member.builder()
                     .name("테스트유저")
-                    .studentId("123456789")
+                    .studentId(123456789)
                     .role(Role.USER)
                     .build();
             memberRepository.save(member);

--- a/src/main/java/com/greedy/zupzup/DataLoader.java
+++ b/src/main/java/com/greedy/zupzup/DataLoader.java
@@ -83,7 +83,7 @@ public class DataLoader implements CommandLineRunner {
             log.info("구역 정보가 이미 존재하여 초기화를 건너뜁니다.");
         }
     }
-    
+
 
     private void initCategoryData() {
         log.info("카테고리 정보를 초기화합니다.");

--- a/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
@@ -61,7 +61,8 @@ public class AuthService {
 
 
     public Member login(LoginCommand command) {
-        Member loginMember = memberRepository.getMemberByStudentId(command.studentId());
+        Member loginMember = memberRepository.findByStudentId(command.studentId())
+                .orElseThrow(() -> new ApplicationException(AuthException.LOGIN_FAILED));
 
         if (!BCrypt.checkpw(command.password(), loginMember.getPassword())) {
             throw new ApplicationException(AuthException.LOGIN_FAILED);

--- a/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
@@ -2,6 +2,8 @@ package com.greedy.zupzup.auth.application;
 
 import com.greedy.zupzup.auth.application.dto.PortalLoginCommand;
 import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.exception.AuthException;
+import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,18 @@ public class AuthService {
 
     private final SejongAuthenticator sejongAuthenticator;
     private final MemberRepository memberRepository;
+
+
+    public SejongAuthInfo verifyStudent(PortalLoginCommand command) {
+        SejongAuthInfo studentAuthInfo = sejongAuthenticator.getStudentAuthInfo(command.portalId(), command.portalPassword());
+
+        if (memberRepository.existsByStudentId(studentAuthInfo.studentId())) {
+            throw new ApplicationException(AuthException.ALREADY_REGISTERED_MEMBER);
+        }
+        return studentAuthInfo;
+    }
+
+
 
     /**
      * 포털 인증만으로 로그인 (데모데이 용) - 정식 출시 전에는 삭제하고, 인증+가입 절차만 열어두기

--- a/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
@@ -15,7 +15,6 @@ public class AuthService {
     private final SejongAuthenticator sejongAuthenticator;
     private final MemberRepository memberRepository;
 
-
     /**
      * 포털 인증만으로 로그인 (데모데이 용) - 정식 출시 전에는 삭제하고, 인증+가입 절차만 열어두기
      */

--- a/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
@@ -2,11 +2,14 @@ package com.greedy.zupzup.auth.application;
 
 import com.greedy.zupzup.auth.application.dto.PortalLoginCommand;
 import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.application.dto.SignupCommand;
 import com.greedy.zupzup.auth.exception.AuthException;
 import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.member.domain.Member;
+import com.greedy.zupzup.member.domain.Role;
 import com.greedy.zupzup.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +31,31 @@ public class AuthService {
     }
 
 
+    @Transactional
+    public Member signup(SignupCommand command) {
+        SejongAuthInfo sejongAuthInfo = command.verifiedInfo();
+
+        if (!sejongAuthInfo.studentId().equals(command.studentId())) {
+            throw new ApplicationException(AuthException.STUDENT_ID_MISMATCH);
+        }
+
+        try {
+            Member newMember = Member.builder()
+                    .name(sejongAuthInfo.studentName())
+                    .studentId(sejongAuthInfo.studentId())
+                    .password(command.password())
+                    .role(Role.USER)
+                    .build();
+
+            System.out.println("가입 ㄱㄱ" + newMember.toString());
+            memberRepository.save(newMember);
+
+            return newMember;
+        } catch (DataIntegrityViolationException e) {
+            throw new ApplicationException(AuthException.ALREADY_REGISTERED_MEMBER);
+        }
+    }
+
 
     /**
      * 포털 인증만으로 로그인 (데모데이 용) - 정식 출시 전에는 삭제하고, 인증+가입 절차만 열어두기
@@ -37,7 +65,11 @@ public class AuthService {
         SejongAuthInfo studentAuthInfo = sejongAuthenticator.getStudentAuthInfo(command.portalId(), command.portalPassword());
          return memberRepository.findByStudentId(studentAuthInfo.studentId())
                 .orElseGet(() -> {
-                    Member newMember = new Member(studentAuthInfo.studentName(), studentAuthInfo.studentId());
+                    Member newMember = Member.builder()
+                            .name(studentAuthInfo.studentName())
+                            .studentId(studentAuthInfo.studentId())
+                            .role(Role.USER)
+                            .build();
                     return memberRepository.save(newMember);
                 });
     }

--- a/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
@@ -1,0 +1,18 @@
+package com.greedy.zupzup.auth.application;
+
+import com.greedy.zupzup.auth.application.dto.PortalLoginCommand;
+import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final SejongAuthenticator sejongAuthenticator;
+    private final MemberRepository memberRepository;
+
+
+
+}

--- a/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
@@ -2,9 +2,11 @@ package com.greedy.zupzup.auth.application;
 
 import com.greedy.zupzup.auth.application.dto.PortalLoginCommand;
 import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +16,17 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
 
+    /**
+     * 포털 인증만으로 로그인 (데모데이 용) - 정식 출시 전에는 삭제하고, 인증+가입 절차만 열어두기
+     */
+    @Transactional
+    public Member authenticateSejongAndLogin(PortalLoginCommand command) {
+        SejongAuthInfo studentAuthInfo = sejongAuthenticator.getStudentAuthInfo(command.portalId(), command.portalPassword());
+         return memberRepository.findByStudentId(studentAuthInfo.studentId())
+                .orElseGet(() -> {
+                    Member newMember = new Member(studentAuthInfo.studentId(), studentAuthInfo.studentName());
+                    return memberRepository.save(newMember);
+                });
+    }
 
 }

--- a/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/AuthService.java
@@ -24,7 +24,7 @@ public class AuthService {
         SejongAuthInfo studentAuthInfo = sejongAuthenticator.getStudentAuthInfo(command.portalId(), command.portalPassword());
          return memberRepository.findByStudentId(studentAuthInfo.studentId())
                 .orElseGet(() -> {
-                    Member newMember = new Member(studentAuthInfo.studentId(), studentAuthInfo.studentName());
+                    Member newMember = new Member(studentAuthInfo.studentName(), studentAuthInfo.studentId());
                     return memberRepository.save(newMember);
                 });
     }

--- a/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
@@ -80,8 +80,6 @@ public class SejongAuthenticator {
         String body = response.body() != null ? response.body().string() : "";
         response.close();
 
-        System.out.println(body);
-
         // var result = 'OK' 라는 코드가 있으면 로그인 성공 -> 그외 로그인 실패
         if (!body.contains(SEJONG_PORTAL_LOGIN_SUCCESS_MESSAGE_IN_HTML)) {
             throw new ApplicationException(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW);

--- a/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
@@ -1,0 +1,213 @@
+package com.greedy.zupzup.auth.application;
+
+import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.exception.AuthException;
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.global.exception.InfrastructureException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SejongAuthenticator {
+
+    private static final int MAX_PORTAL_LOGIN_RETRY_COUNT = 3;
+    private static final int STUDENT_INFO_MAJOR_INDEX = 0;
+    private static final int STUDENT_INFO_ID_INDEX = 1;
+    private static final int STUDENT_INFO_NAME_INDEX = 2;
+
+    private static final String SEJONG_PORTAL_LOGIN_URL = "https://portal.sejong.ac.kr/jsp/login/login_action.jsp";
+    private static final String SEJONG_SSO_URL = "http://classic.sejong.ac.kr/_custom/sejong/sso/sso-return.jsp?returnUrl=https://classic.sejong.ac.kr/classic/index.do";
+    private static final String SEJONG_READING_SITE_URL = "https://classic.sejong.ac.kr/classic/reading/status.do";
+    private static final String STUDENT_INFO_TABLE_TR = ".b-con-box:has(h4.b-h4-tit01:contains(사용자 정보)) table.b-board-table tbody tr";
+    private static final String SEJONG_PORTAL_LOGIN_FAILED_MESSAGE_IN_HTML = "아이디나 비밀번호가 일치하지 않습니다";
+
+
+    /**
+     * 세종대학교 포털 로그인을 통해 학생 인증을 진행합니다.
+     */
+    public SejongAuthInfo getStudentAuthInfo(String portalId, String portalPassword) {
+
+        try {
+            OkHttpClient client = buildClient();
+            doPortalLogin(client, portalId, portalPassword);
+
+            ssoRedirectToReadingSite(client);
+            String readingPageHtml = fetchReadingPageHtml(client);
+
+            return parseHTMLAndGetMemberInfo(readingPageHtml);
+        } catch (IOException e) {
+            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+        }
+    }
+
+
+    /**
+     * 세종대학교 포털 로그인을 진행합니다.
+     */
+    private void doPortalLogin(OkHttpClient client, String portalId, String portalPassword) throws IOException {
+
+        FormBody formBody = new FormBody.Builder()
+                .add("mainLogin", "N")
+                .add("rtUrl", "library.sejong.ac.kr")
+                .add("id", portalId)
+                .add("password", portalPassword)
+                .build();
+
+        Request request = new Request.Builder()
+                .url(SEJONG_PORTAL_LOGIN_URL)
+                .post(formBody)
+                .header("Host", "portal.sejong.ac.kr")
+                .header("Referer", "https://portal.sejong.ac.kr")
+                .header("Cookie", "chknos=false")
+                .build();
+        
+        Response response = executeWithRetry(client, request);
+
+        String body = response.body() != null ? response.body().string() : "";
+        response.close();
+
+        if (body.contains(SEJONG_PORTAL_LOGIN_FAILED_MESSAGE_IN_HTML)) {
+            throw new ApplicationException(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW);
+        }
+    }
+
+
+    /**
+     * 세종대학교 포털 로그인을 요청을 위한 OkHttpClient 객체를 생성합니다.
+     */
+    private OkHttpClient buildClient() {
+        try {
+            // SSLContext 생성, 모든 인증서 신뢰 설정
+            SSLContext sslCtx = SSLContext.getInstance("SSL");
+            sslCtx.init(null, new TrustManager[]{trustAllManager()}, new java.security.SecureRandom());
+            SSLSocketFactory sslFactory = sslCtx.getSocketFactory();
+
+            // hostnameVerifier: 모든 호스트네임에 대해 OK 처리
+            HostnameVerifier hostnameVerifier = (hostname, session) -> true;
+
+            // 쿠키 관리
+            CookieManager cookieManager = new CookieManager();
+            cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+
+            // OkHttpClient 생성
+            return new OkHttpClient.Builder()
+                    .sslSocketFactory(sslFactory, trustAllManager())
+                    .hostnameVerifier(hostnameVerifier)
+                    .cookieJar(new JavaNetCookieJar(cookieManager))
+                    .build();
+
+        } catch (Exception e) {
+            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+        }
+    }
+
+
+    /**
+     * 포털 로그인 성공 후 생성된 세션(쿠키)을 이용하여 고전독서인증 사이트로 SSO 인증을 요청합니다
+     */
+    private void ssoRedirectToReadingSite(OkHttpClient client) throws IOException {
+        Request ssoReq = new Request.Builder().url(SEJONG_SSO_URL).get().build();
+        try (Response ssoResp = client.newCall(ssoReq).execute()) {
+            if (!ssoResp.isSuccessful()) {
+                throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+            }
+        }
+    }
+
+
+    /**
+     * 로그인된 세션을 사용하여 고전독서인증 페이지의 HTML을 가져옵니다.
+     */
+    private String fetchReadingPageHtml(OkHttpClient client) throws IOException {
+
+        Request readingSiteRequest = new Request.Builder()
+                .url(SEJONG_READING_SITE_URL)
+                .get()
+                .build();
+
+        try (Response finalResp = client.newCall(readingSiteRequest).execute()) {
+            if (finalResp.body() == null || finalResp.code() != 200) {
+                throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+            }
+            return finalResp.body().string();
+        }
+    }
+
+
+    /**
+     * 고전독서 페이지에서 학생 정보를 추출합니다.
+     */
+    private SejongAuthInfo parseHTMLAndGetMemberInfo(String html) {
+        Document doc = Jsoup.parse(html);
+
+        List<String> rowValues = new ArrayList<>();
+
+        doc.select(STUDENT_INFO_TABLE_TR).forEach(tr -> {
+            String value = tr.select("td").text().trim();
+            rowValues.add(value);
+        });
+
+        String major = getValueFromList(rowValues, STUDENT_INFO_MAJOR_INDEX);
+        String studentId = getValueFromList(rowValues, STUDENT_INFO_ID_INDEX);
+        String studentName = getValueFromList(rowValues, STUDENT_INFO_NAME_INDEX);
+
+        return new SejongAuthInfo(studentId, studentName);
+    }
+
+    private String getValueFromList(List<String> list, int index) {
+        return list.size() > index ? list.get(index) : null;
+    }
+
+
+    /**
+     * 포털 로그인을 시도합니다.
+     */
+    private Response executeWithRetry(OkHttpClient client, Request request) throws IOException {
+        Response response = null;
+        int tryCount = 0;
+        while (tryCount < MAX_PORTAL_LOGIN_RETRY_COUNT) {
+            try {
+                response = client.newCall(request).execute();
+                if (response.isSuccessful()) {
+                    return response;
+                }
+            } catch (SocketTimeoutException e) {
+                tryCount++;
+                log.warn("[PortalLogin] Timeout 발생 -> 재시도... ({}회)", tryCount);
+            }
+        }
+        throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+    }
+
+
+    private X509TrustManager trustAllManager() {
+        return new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                return new java.security.cert.X509Certificate[0];
+            }
+        };
+    }
+}

--- a/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
@@ -33,7 +33,7 @@ public class SejongAuthenticator {
     private static final String SEJONG_SSO_URL = "http://classic.sejong.ac.kr/_custom/sejong/sso/sso-return.jsp?returnUrl=https://classic.sejong.ac.kr/classic/index.do";
     private static final String SEJONG_READING_SITE_URL = "https://classic.sejong.ac.kr/classic/reading/status.do";
     private static final String STUDENT_INFO_TABLE_TR = ".b-con-box:has(h4.b-h4-tit01:contains(사용자 정보)) table.b-board-table tbody tr";
-    private static final String SEJONG_PORTAL_LOGIN_FAILED_MESSAGE_IN_HTML = "아이디나 비밀번호가 일치하지 않습니다";
+    private static final String SEJONG_PORTAL_LOGIN_SUCCESS_MESSAGE_IN_HTML = "var result = 'OK'";
 
 
     /**
@@ -80,9 +80,13 @@ public class SejongAuthenticator {
         String body = response.body() != null ? response.body().string() : "";
         response.close();
 
-        if (body.contains(SEJONG_PORTAL_LOGIN_FAILED_MESSAGE_IN_HTML)) {
+        System.out.println(body);
+
+        // var result = 'OK' 라는 코드가 있으면 로그인 성공 -> 그외 로그인 실패
+        if (!body.contains(SEJONG_PORTAL_LOGIN_SUCCESS_MESSAGE_IN_HTML)) {
             throw new ApplicationException(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW);
         }
+
     }
 
 
@@ -161,7 +165,7 @@ public class SejongAuthenticator {
             rowValues.add(value);
         });
 
-        String major = getValueFromList(rowValues, STUDENT_INFO_MAJOR_INDEX);
+        String major = getValueFromList(rowValues, STUDENT_INFO_MAJOR_INDEX);   // 일단 사용 x
         String studentId = getValueFromList(rowValues, STUDENT_INFO_ID_INDEX);
         String studentName = getValueFromList(rowValues, STUDENT_INFO_NAME_INDEX);
 

--- a/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
@@ -166,10 +166,21 @@ public class SejongAuthenticator {
         });
 
         String major = getValueFromList(rowValues, STUDENT_INFO_MAJOR_INDEX);   // 일단 사용 x
-        String studentId = getValueFromList(rowValues, STUDENT_INFO_ID_INDEX);
+        String studentIdString = getValueFromList(rowValues, STUDENT_INFO_ID_INDEX);
         String studentName = getValueFromList(rowValues, STUDENT_INFO_NAME_INDEX);
 
-        return new SejongAuthInfo(studentId, studentName);
+        if (studentIdString == null || studentIdString.isBlank() || studentName == null || studentName.isBlank()) {
+            log.warn("포탈 로그인 | 고전 독서 페이지에서 학생 정보 추출 실패");
+            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
+        }
+
+        try {
+            int studentId = Integer.parseInt(studentIdString);
+            return new SejongAuthInfo(studentId, studentName);
+        } catch (NumberFormatException e) {
+            log.warn("포탈 로그인 | 학번 -> 정수 파싱 오류 studentId={}, studentName={}", studentIdString, studentName);
+            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
+        }
     }
 
     private String getValueFromList(List<String> list, int index) {
@@ -191,7 +202,7 @@ public class SejongAuthenticator {
                 }
             } catch (SocketTimeoutException e) {
                 tryCount++;
-                log.warn("포탈 로그인 타임아웃 발생 (재시도: {}회)", tryCount);
+                log.warn("포탈 로그인 | 타임아웃 발생 (재시도: {}회)", tryCount);
             }
         }
         throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);

--- a/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/SejongAuthenticator.java
@@ -50,7 +50,7 @@ public class SejongAuthenticator {
 
             return parseHTMLAndGetMemberInfo(readingPageHtml);
         } catch (IOException e) {
-            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
         }
     }
 
@@ -115,7 +115,7 @@ public class SejongAuthenticator {
                     .build();
 
         } catch (Exception e) {
-            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
         }
     }
 
@@ -127,7 +127,7 @@ public class SejongAuthenticator {
         Request ssoReq = new Request.Builder().url(SEJONG_SSO_URL).get().build();
         try (Response ssoResp = client.newCall(ssoReq).execute()) {
             if (!ssoResp.isSuccessful()) {
-                throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+                throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
             }
         }
     }
@@ -145,7 +145,7 @@ public class SejongAuthenticator {
 
         try (Response finalResp = client.newCall(readingSiteRequest).execute()) {
             if (finalResp.body() == null || finalResp.code() != 200) {
-                throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+                throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
             }
             return finalResp.body().string();
         }
@@ -191,10 +191,10 @@ public class SejongAuthenticator {
                 }
             } catch (SocketTimeoutException e) {
                 tryCount++;
-                log.warn("[PortalLogin] Timeout 발생 -> 재시도... ({}회)", tryCount);
+                log.warn("포탈 로그인 타임아웃 발생 (재시도: {}회)", tryCount);
             }
         }
-        throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FILED);
+        throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
     }
 
 

--- a/src/main/java/com/greedy/zupzup/auth/application/dto/LoginCommand.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/dto/LoginCommand.java
@@ -1,0 +1,7 @@
+package com.greedy.zupzup.auth.application.dto;
+
+public record LoginCommand(
+        Integer studentId,
+        String password
+) {
+}

--- a/src/main/java/com/greedy/zupzup/auth/application/dto/PortalLoginCommand.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/dto/PortalLoginCommand.java
@@ -1,0 +1,7 @@
+package com.greedy.zupzup.auth.application.dto;
+
+public record PortalLoginCommand(
+        String portalId,
+        String portalPassword
+) {
+}

--- a/src/main/java/com/greedy/zupzup/auth/application/dto/SejongAuthInfo.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/dto/SejongAuthInfo.java
@@ -1,7 +1,7 @@
 package com.greedy.zupzup.auth.application.dto;
 
 public record SejongAuthInfo(
-        String studentId,
+        Integer studentId,
         String studentName
 ) {
 }

--- a/src/main/java/com/greedy/zupzup/auth/application/dto/SejongAuthInfo.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/dto/SejongAuthInfo.java
@@ -1,4 +1,7 @@
 package com.greedy.zupzup.auth.application.dto;
 
-public record SejongAuthInfo() {
+public record SejongAuthInfo(
+        String studentId,
+        String studentName
+) {
 }

--- a/src/main/java/com/greedy/zupzup/auth/application/dto/SejongAuthInfo.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/dto/SejongAuthInfo.java
@@ -1,0 +1,4 @@
+package com.greedy.zupzup.auth.application.dto;
+
+public record SejongAuthInfo() {
+}

--- a/src/main/java/com/greedy/zupzup/auth/application/dto/SignupCommand.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/dto/SignupCommand.java
@@ -1,0 +1,8 @@
+package com.greedy.zupzup.auth.application.dto;
+
+public record SignupCommand(
+        SejongAuthInfo verifiedInfo,
+        int studentId,
+        String password
+) {
+}

--- a/src/main/java/com/greedy/zupzup/auth/application/dto/SignupCommand.java
+++ b/src/main/java/com/greedy/zupzup/auth/application/dto/SignupCommand.java
@@ -2,7 +2,7 @@ package com.greedy.zupzup.auth.application.dto;
 
 public record SignupCommand(
         SejongAuthInfo verifiedInfo,
-        int studentId,
+        Integer studentId,
         String password
 ) {
 }

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -15,7 +15,8 @@ public enum AuthException implements ExceptionCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 형식", "인증 정보가 올바르지 않습니다. 다시 로그인해주세요."),
     UNAUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청", "로그인이 필요합니다."),
     ALREADY_REGISTERED_MEMBER(HttpStatus.BAD_REQUEST, "가입된 사용자", "이미 가입된 사용자 입니다."),
-    SEJONG_VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "세종대학교 인증 누락", "세종대학교 인증이 필요합니ㅏㄷ")
+    SEJONG_VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "세종대학교 인증 필요", "세종대학교 인증이 만료되었거나, 아직 인증하지 않았습니다."),
+    STUDENT_ID_MISMATCH(HttpStatus.BAD_REQUEST, "인증 정보 불일치", "가입 요청된 학번과, 인증된 학번이 일치하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -17,7 +17,7 @@ public enum AuthException implements ExceptionCode {
     ALREADY_REGISTERED_MEMBER(HttpStatus.CONFLICT, "가입된 사용자", "이미 가입된 사용자 입니다."),
     SEJONG_VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "세종대학교 인증 필요", "세종대학교 인증이 만료되었거나, 아직 인증하지 않았습니다."),
     STUDENT_ID_MISMATCH(HttpStatus.BAD_REQUEST, "인증 정보 불일치", "가입 요청된 학번과, 인증된 학번이 일치하지 않습니다."),
-    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패", "아이디와 패스워드가 일치하지 않습니다.")
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패", "아이디 또는 패스워드가 일치하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -9,16 +9,15 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthException implements ExceptionCode {
 
-
-    INVALID_SEJONG_PORTAL_LOGIN_ID_PW(HttpStatus.BAD_REQUEST, "세종대학교 포털 로그인 실패", "세종대학교 학생 인증에 실패했습니다. 아이디 비밀번호를 다시한번 확인해 주세요."),
-    SEJONG_PORTAL_LOGIN_FILED(HttpStatus.SERVICE_UNAVAILABLE, "세종대학교 포털 서버 통신 오류", "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
-    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "로그인 만료", "로그인이 만료 만료되었습니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "access token 형식 오류", "access token이 유효하지 않습니다."),
+    INVALID_SEJONG_PORTAL_LOGIN_ID_PW(HttpStatus.BAD_REQUEST, "세종대학교 포털 로그인 실패", "세종대학교 학생 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요."),
+    SEJONG_PORTAL_LOGIN_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "세종대학교 포털 서버 통신 오류", "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "로그인 만료", "로그인이 만료되었습니다. 다시 로그인해주세요."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 형식", "인증 정보가 올바르지 않습니다. 다시 로그인해주세요."),
     UNAUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청", "로그인이 필요합니다."),
     ;
-
 
     private final HttpStatus httpStatus;
     private final String title;
     private final String detail;
+
 }

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -1,0 +1,21 @@
+package com.greedy.zupzup.auth.exception;
+
+import com.greedy.zupzup.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthException implements ExceptionCode {
+
+
+    INVALID_SEJONG_PORTAL_LOGIN_ID_PW(HttpStatus.BAD_REQUEST, "세종대학교 포털 로그인 실패", "세종대학교 학생 인증에 실패했습니다. 아이디 비밀번호를 다시한번 확인해 주세요."),
+    SEJONG_PORTAL_LOGIN_FILED(HttpStatus.SERVICE_UNAVAILABLE, "세종대학교 포털 서버 통신 오류", "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.")
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+}

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -11,7 +11,10 @@ public enum AuthException implements ExceptionCode {
 
 
     INVALID_SEJONG_PORTAL_LOGIN_ID_PW(HttpStatus.BAD_REQUEST, "세종대학교 포털 로그인 실패", "세종대학교 학생 인증에 실패했습니다. 아이디 비밀번호를 다시한번 확인해 주세요."),
-    SEJONG_PORTAL_LOGIN_FILED(HttpStatus.SERVICE_UNAVAILABLE, "세종대학교 포털 서버 통신 오류", "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.")
+    SEJONG_PORTAL_LOGIN_FILED(HttpStatus.SERVICE_UNAVAILABLE, "세종대학교 포털 서버 통신 오류", "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "로그인 만료", "로그인이 만료 만료되었습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "access token 형식 오류", "access token이 유효하지 않습니다."),
+    UNAUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청", "로그인이 필요합니다."),
     ;
 
 

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -9,11 +9,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthException implements ExceptionCode {
 
-    INVALID_SEJONG_PORTAL_LOGIN_ID_PW(HttpStatus.BAD_REQUEST, "세종대학교 포털 로그인 실패", "세종대학교 학생 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요."),
+    INVALID_SEJONG_PORTAL_LOGIN_ID_PW(HttpStatus.BAD_REQUEST, "세종대학교 포털 로그인 실패", "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요."),
     SEJONG_PORTAL_LOGIN_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "세종대학교 포털 서버 통신 오류", "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "로그인 만료", "로그인이 만료되었습니다. 다시 로그인해주세요."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 형식", "인증 정보가 올바르지 않습니다. 다시 로그인해주세요."),
     UNAUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청", "로그인이 필요합니다."),
+    ALREADY_REGISTERED_MEMBER(HttpStatus.BAD_REQUEST, "가입된 사용자", "이미 가입된 사용자 입니다."),
+    SEJONG_VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "세종대학교 인증 누락", "세종대학교 인증이 필요합니ㅏㄷ")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthException implements ExceptionCode {
 
-    INVALID_SEJONG_PORTAL_LOGIN_ID_PW(HttpStatus.BAD_REQUEST, "세종대학교 포털 로그인 실패", "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요."),
+    INVALID_SEJONG_PORTAL_LOGIN_ID_PW(HttpStatus.UNAUTHORIZED, "세종대학교 포털 로그인 실패", "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요."),
     SEJONG_PORTAL_LOGIN_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "세종대학교 포털 서버 통신 오류", "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "로그인 만료", "로그인이 만료되었습니다. 다시 로그인해주세요."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 형식", "인증 정보가 올바르지 않습니다. 다시 로그인해주세요."),
@@ -17,7 +17,7 @@ public enum AuthException implements ExceptionCode {
     ALREADY_REGISTERED_MEMBER(HttpStatus.BAD_REQUEST, "가입된 사용자", "이미 가입된 사용자 입니다."),
     SEJONG_VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "세종대학교 인증 필요", "세종대학교 인증이 만료되었거나, 아직 인증하지 않았습니다."),
     STUDENT_ID_MISMATCH(HttpStatus.BAD_REQUEST, "인증 정보 불일치", "가입 요청된 학번과, 인증된 학번이 일치하지 않습니다."),
-    LOGIN_FAILED(HttpStatus.BAD_REQUEST, "로그인 실패", "아이디와 패스워드가 일치하지 않습니다.")
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패", "아이디와 패스워드가 일치하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -14,7 +14,7 @@ public enum AuthException implements ExceptionCode {
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "로그인 만료", "로그인이 만료되었습니다. 다시 로그인해주세요."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 형식", "인증 정보가 올바르지 않습니다. 다시 로그인해주세요."),
     UNAUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청", "로그인이 필요합니다."),
-    ALREADY_REGISTERED_MEMBER(HttpStatus.BAD_REQUEST, "가입된 사용자", "이미 가입된 사용자 입니다."),
+    ALREADY_REGISTERED_MEMBER(HttpStatus.CONFLICT, "가입된 사용자", "이미 가입된 사용자 입니다."),
     SEJONG_VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "세종대학교 인증 필요", "세종대학교 인증이 만료되었거나, 아직 인증하지 않았습니다."),
     STUDENT_ID_MISMATCH(HttpStatus.BAD_REQUEST, "인증 정보 불일치", "가입 요청된 학번과, 인증된 학번이 일치하지 않습니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패", "아이디와 패스워드가 일치하지 않습니다.")

--- a/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
+++ b/src/main/java/com/greedy/zupzup/auth/exception/AuthException.java
@@ -16,7 +16,8 @@ public enum AuthException implements ExceptionCode {
     UNAUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청", "로그인이 필요합니다."),
     ALREADY_REGISTERED_MEMBER(HttpStatus.BAD_REQUEST, "가입된 사용자", "이미 가입된 사용자 입니다."),
     SEJONG_VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "세종대학교 인증 필요", "세종대학교 인증이 만료되었거나, 아직 인증하지 않았습니다."),
-    STUDENT_ID_MISMATCH(HttpStatus.BAD_REQUEST, "인증 정보 불일치", "가입 요청된 학번과, 인증된 학번이 일치하지 않습니다.")
+    STUDENT_ID_MISMATCH(HttpStatus.BAD_REQUEST, "인증 정보 불일치", "가입 요청된 학번과, 인증된 학번이 일치하지 않습니다."),
+    LOGIN_FAILED(HttpStatus.BAD_REQUEST, "로그인 실패", "아이디와 패스워드가 일치하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greedy/zupzup/auth/infrastructure/BCryptPasswordEncoder.java
+++ b/src/main/java/com/greedy/zupzup/auth/infrastructure/BCryptPasswordEncoder.java
@@ -1,0 +1,18 @@
+package com.greedy.zupzup.auth.infrastructure;
+
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BCryptPasswordEncoder implements PasswordEncoder {
+
+    @Override
+    public String encode(String rawPassword) {
+        return BCrypt.hashpw(rawPassword, BCrypt.gensalt());
+    }
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return BCrypt.checkpw(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/auth/infrastructure/PasswordEncoder.java
+++ b/src/main/java/com/greedy/zupzup/auth/infrastructure/PasswordEncoder.java
@@ -1,0 +1,6 @@
+package com.greedy.zupzup.auth.infrastructure;
+
+public interface PasswordEncoder {
+    String encode(String rawPassword);
+    boolean matches(String rawPassword, String encodedPassword);
+}

--- a/src/main/java/com/greedy/zupzup/auth/infrastructure/SejongAuthenticator.java
+++ b/src/main/java/com/greedy/zupzup/auth/infrastructure/SejongAuthenticator.java
@@ -1,4 +1,4 @@
-package com.greedy.zupzup.auth.application;
+package com.greedy.zupzup.auth.infrastructure;
 
 import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
 import com.greedy.zupzup.auth.exception.AuthException;

--- a/src/main/java/com/greedy/zupzup/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/greedy/zupzup/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,66 @@
+package com.greedy.zupzup.auth.jwt;
+
+import com.greedy.zupzup.auth.exception.AuthException;
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.member.domain.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final String accessSecretKey;
+    public final int accessExpiration;
+
+    public JwtTokenProvider(@Value("${zupzup.auth.jwt.access.secret}") String accessSecretKey,
+                            @Value("${zupzup.auth.jwt.access.expiration}") int accessExpiration) {
+        this.accessSecretKey = accessSecretKey;
+        this.accessExpiration = accessExpiration;
+    }
+
+
+    public String createAccessToken(Member member) {
+        Date now = new Date();
+        Date expirationTime = new Date(now.getTime() + accessExpiration);
+
+        return Jwts.builder()
+                .setSubject(member.getId().toString())
+                .setIssuedAt(now)
+                .setExpiration(expirationTime)
+                .signWith(Keys.hmacShaKeyFor(accessSecretKey.getBytes()))
+                .compact();
+    }
+
+
+    public Long getLoginMemberId(String accessToken) {
+        return Long.valueOf(
+                getAccessClaims(accessToken)
+                        .getSubject()
+        );
+    }
+
+
+    private Claims getAccessClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(accessSecretKey.getBytes()))
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new ApplicationException(AuthException.ACCESS_TOKEN_EXPIRED);
+        } catch (IllegalArgumentException e) {
+            throw new ApplicationException(AuthException.UNAUTHENTICATED_REQUEST);
+        } catch (JwtException e) {
+            throw new ApplicationException(AuthException.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+}

--- a/src/main/java/com/greedy/zupzup/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/greedy/zupzup/auth/jwt/JwtTokenProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/greedy/zupzup/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/greedy/zupzup/auth/jwt/JwtTokenProvider.java
@@ -18,18 +18,18 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private final String accessSecretKey;
-    public final int accessExpiration;
+    public final int accessExpirationSecond;
 
     public JwtTokenProvider(@Value("${zupzup.auth.jwt.access.secret}") String accessSecretKey,
-                            @Value("${zupzup.auth.jwt.access.expiration}") int accessExpiration) {
+                            @Value("${zupzup.auth.jwt.access.expiration-second}") int accessExpirationSecond) {
         this.accessSecretKey = accessSecretKey;
-        this.accessExpiration = accessExpiration;
+        this.accessExpirationSecond = accessExpirationSecond;
     }
 
 
     public String createAccessToken(Member member) {
         Date now = new Date();
-        Date expirationTime = new Date(now.getTime() + accessExpiration);
+        Date expirationTime = new Date(now.getTime() + (accessExpirationSecond * 1000L));
 
         return Jwts.builder()
                 .setSubject(member.getId().toString())

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -1,0 +1,23 @@
+package com.greedy.zupzup.auth.presentation;
+
+import com.greedy.zupzup.auth.application.SejongAuthenticator;
+import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.presentation.dto.PortalLoginRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+
+
+
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -1,7 +1,6 @@
 package com.greedy.zupzup.auth.presentation;
 
 import com.greedy.zupzup.auth.application.AuthService;
-import com.greedy.zupzup.auth.application.SejongAuthenticator;
 import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
 import com.greedy.zupzup.auth.exception.AuthException;
 import com.greedy.zupzup.auth.jwt.JwtTokenProvider;

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
 
 
-    @PostMapping("/verify-student")
+    @PostMapping("/verify-sejong")
     public ResponseEntity<VerifiedStudentResponse> verifyStudent(@RequestBody @Valid PortalLoginRequest portalLoginRequest, HttpServletRequest httpRequest) {
         SejongAuthInfo sejongAuthInfo = authService.verifyStudent(portalLoginRequest.toCommand());
 
@@ -88,10 +88,10 @@ public class AuthController {
      * 포털 인증만으로 로그인 (데모데이 용) - 정식 출시 전에는 삭제하고, 인증+가입 절차만 열어두기
      */
     @PostMapping("/login/portal")
-    public ResponseEntity<Void> portalLogin(@RequestBody @Valid PortalLoginRequest request, HttpServletResponse response) {
+    public ResponseEntity<LoginResponse> portalLogin(@RequestBody @Valid PortalLoginRequest request, HttpServletResponse response) {
         Member loginMember = authService.authenticateSejongAndLogin(request.toCommand());
         setAccessToken(response, loginMember);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(LoginResponse.from(loginMember));
     }
 
     private void setAccessToken(HttpServletResponse response, Member member) {

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
 
 
     @PostMapping("/verify-sejong")
-    public ResponseEntity<VerifiedStudentResponse> verifyStudent(@RequestBody @Valid PortalLoginRequest portalLoginRequest, HttpServletRequest httpRequest) {
+    public ResponseEntity<VerifiedStudentResponse> verifySejong(@RequestBody @Valid PortalLoginRequest portalLoginRequest, HttpServletRequest httpRequest) {
         SejongAuthInfo sejongAuthInfo = authService.verifyStudent(portalLoginRequest.toCommand());
 
         HttpSession session = httpRequest.getSession();

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -3,11 +3,17 @@ package com.greedy.zupzup.auth.presentation;
 import com.greedy.zupzup.auth.application.AuthService;
 import com.greedy.zupzup.auth.application.SejongAuthenticator;
 import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.exception.AuthException;
 import com.greedy.zupzup.auth.jwt.JwtTokenProvider;
 import com.greedy.zupzup.auth.presentation.dto.PortalLoginRequest;
+import com.greedy.zupzup.auth.presentation.dto.SignupRequest;
+import com.greedy.zupzup.auth.presentation.dto.VerifiedStudentResponse;
+import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.global.util.CookieUtil;
 import com.greedy.zupzup.member.domain.Member;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,9 +28,29 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private static final String SEJONG_VERIFICATION_INFO_SESSION_KEY = "sejongAuthInfo";
+
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
 
+
+    @PostMapping("/verify-student")
+    public ResponseEntity<VerifiedStudentResponse> verifyStudent(@RequestBody @Valid PortalLoginRequest portalLoginRequest, HttpServletRequest httpRequest) {
+        SejongAuthInfo sejongAuthInfo = authService.verifyStudent(portalLoginRequest.toCommand());
+
+        HttpSession session = httpRequest.getSession();
+        session.setAttribute(SEJONG_VERIFICATION_INFO_SESSION_KEY, sejongAuthInfo);
+
+        return ResponseEntity.ok(VerifiedStudentResponse.from(sejongAuthInfo.studentId()));
+    }
+
+
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        CookieUtil.setToken("", 0, response);
+        return ResponseEntity.ok().build();
+    }
 
     /**
      * 포털 인증만으로 로그인 (데모데이 용) - 정식 출시 전에는 삭제하고, 인증+가입 절차만 열어두기
@@ -38,10 +64,5 @@ public class AuthController {
     }
 
 
-    @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletResponse response) {
-        CookieUtil.setToken("", 0, response);
-        return ResponseEntity.ok().build();
-    }
 
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -96,7 +96,7 @@ public class AuthController implements AuthControllerDocs {
 
     private void setAccessToken(HttpServletResponse response, Member member) {
         String accessToken = jwtTokenProvider.createAccessToken(member);
-        CookieUtil.setToken(accessToken, jwtTokenProvider.accessExpiration, response);
+        CookieUtil.setToken(accessToken, jwtTokenProvider.accessExpirationSecond, response);
     }
 
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -1,8 +1,13 @@
 package com.greedy.zupzup.auth.presentation;
 
+import com.greedy.zupzup.auth.application.AuthService;
 import com.greedy.zupzup.auth.application.SejongAuthenticator;
 import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.jwt.JwtTokenProvider;
 import com.greedy.zupzup.auth.presentation.dto.PortalLoginRequest;
+import com.greedy.zupzup.global.util.CookieUtil;
+import com.greedy.zupzup.member.domain.Member;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +22,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
 
+    /**
+     * 포털 인증만으로 로그인 (데모데이 용) - 정식 출시 전에는 삭제하고, 인증+가입 절차만 열어두기
+     */
+    @PostMapping("/login/portal")
+    public ResponseEntity<Void> portalLogin(@RequestBody @Valid PortalLoginRequest request, HttpServletResponse response) {
+        Member loginMember = authService.authenticateSejongAndLogin(request.toCommand());
+        String accessToken = jwtTokenProvider.createAccessToken(loginMember);
+        CookieUtil.setToken(accessToken, jwtTokenProvider.accessExpiration, response);
+        return ResponseEntity.ok().build();
+    }
+
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        CookieUtil.setToken("", 0, response);
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -7,6 +7,7 @@ import com.greedy.zupzup.auth.exception.AuthException;
 import com.greedy.zupzup.auth.jwt.JwtTokenProvider;
 import com.greedy.zupzup.auth.presentation.dto.PortalLoginRequest;
 import com.greedy.zupzup.auth.presentation.dto.SignupRequest;
+import com.greedy.zupzup.auth.presentation.dto.SignupResponse;
 import com.greedy.zupzup.auth.presentation.dto.VerifiedStudentResponse;
 import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.global.util.CookieUtil;
@@ -21,6 +22,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 
 @RestController
@@ -45,12 +48,37 @@ public class AuthController {
     }
 
 
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponse> signup(@RequestBody @Valid SignupRequest signupRequest,
+                                                 HttpServletRequest httpRequest, HttpServletResponse response) {
+        HttpSession session = httpRequest.getSession(false);
+        SejongAuthInfo sejongAuthInfo = checkSessionAndGetSejongAuthInfo(session);
+
+        Member member = authService.signup(signupRequest.toCommand(sejongAuthInfo));
+
+        // 세종대학교 인증 세션 종료
+        session.invalidate();
+
+        String accessToken = jwtTokenProvider.createAccessToken(member);
+        CookieUtil.setToken(accessToken, jwtTokenProvider.accessExpiration, response);
+        return ResponseEntity.created(URI.create("/members/" + member.getId()))
+                .body(SignupResponse.of(member));
+    }
+
+    public SejongAuthInfo checkSessionAndGetSejongAuthInfo(HttpSession session) {
+        if (session == null || session.getAttribute(SEJONG_VERIFICATION_INFO_SESSION_KEY) == null) {
+            throw new ApplicationException(AuthException.SEJONG_VERIFICATION_EXPIRED);
+        }
+        return (SejongAuthInfo) session.getAttribute(SEJONG_VERIFICATION_INFO_SESSION_KEY);
+    }
+
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletResponse response) {
         CookieUtil.setToken("", 0, response);
         return ResponseEntity.ok().build();
     }
+
 
     /**
      * 포털 인증만으로 로그인 (데모데이 용) - 정식 출시 전에는 삭제하고, 인증+가입 절차만 열어두기
@@ -62,7 +90,5 @@ public class AuthController {
         CookieUtil.setToken(accessToken, jwtTokenProvider.accessExpiration, response);
         return ResponseEntity.ok().build();
     }
-
-
-
+    
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -25,7 +25,7 @@ import java.net.URI;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
 
     private static final String SEJONG_VERIFICATION_INFO_SESSION_KEY = "sejongAuthInfo";
 

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthControllerDocs.java
@@ -1,0 +1,361 @@
+package com.greedy.zupzup.auth.presentation;
+
+import com.greedy.zupzup.auth.presentation.dto.*;
+import com.greedy.zupzup.global.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Auth", description = "세종대학교 인증/가입 및 회원 로그인/로그아웃 관련 API")
+public interface AuthControllerDocs {
+
+
+    @Operation(summary = "세종대학교 인증",
+            description = "세종대학교 포털 아이디와 비밀번호를 통해 재학생임을 인증합니다. 성공 시, 서버 세션에 인증 정보가 저장됩니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "세종대학교 포털 인증에 성공하고, 서버 세션에 인증 정보가 저장된 경우",
+                    content = @Content(schema = @Schema(implementation = VerifiedStudentResponse.class),
+                            examples = @ExampleObject(name = "세종대학교 인증 성공 예시", value = """
+                                    {
+                                        "studentId": 20011222,
+                                        "message": "세종대학교 인증에 성공했습니다."
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "400", description = "요청 본문의 portalId 또는 portalPassword가 누락되었거나 형식이 올바르지 않은 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "잘못된 요청 본문 (body) 예시", value = """
+                                    {
+                                        "title": "잘못된 요청 본문",
+                                        "status": 400,
+                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
+                                        "instance": "/api/auth/verify-sejong"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "401", description = "제출된 portalId와 portalPassword가 실제 포털 정보와 일치하지 않아 인증에 실패한 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "포털 로그인 실패 예시", value = """
+                                    {
+                                        "title": "세종대학교 포털 로그인 실패",
+                                        "status": 401,
+                                        "detail": "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요.",
+                                        "instance": "/api/auth/verify-sejong"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "409", description = "인증에 성공했으나, 해당 학번으로 이미 서비스에 가입된 회원이 존재하는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "이미 가입된 사용자 예시", value = """
+                                    {
+                                        "title": "가입된 사용자",
+                                        "status": 409,
+                                        "detail": "이미 가입된 사용자 입니다.",
+                                        "instance": "/api/auth/verify-sejong"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "503", description = "세종대학교 포털 서버 자체의 문제나 네트워크 오류로 인해 인증 시도가 불가능한 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "포털 인증 실패 예시", value = """
+                                    {
+                                        "title": "세종대학교 포털 서버 통신 오류",
+                                        "status": 503,
+                                        "detail": "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+                                        "instance": "/api/auth/verify-sejong"
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<VerifiedStudentResponse> verifySejong(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "세종대학교 포털 인증 요청",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PortalLoginRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "정상 요청 예시",
+                                            value = """
+                                                {
+                                                    "portalId": "2001111 (본인 포탈 로그인 아이디)",
+                                                    "portalPassword": "asdasdasd (본인 포탈 로그인 PW)"
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ) @RequestBody @Valid PortalLoginRequest portalLoginRequest,
+            @Parameter(hidden = true) HttpServletRequest httpRequest
+
+    );
+
+
+    @Operation(summary = "회원가입",
+            description = "세종대학교 학생 인증 후, 추가 정보를 입력하여 회원가입을 완료합니다. 학생 인증을 먼저 완료해야 합니다.",
+            security = @SecurityRequirement(name = "sejongSessionAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "회원가입에 성공하고, 새로운 회원 리소스가 성공적으로 생성된 경우",
+                    content = @Content(schema = @Schema(implementation = SignupResponse.class),
+                            examples = @ExampleObject(name = "회원가입 성공 예시", value = """
+                                    {
+                                        "memberId": 2,
+                                        "message": "회원가입에 성공했습니다!"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "400", description = "요청 본문의 password 등이 서버에서 정의한 유효성 규칙(예: 길이, 형식)을 통과하지 못한 경우 + 요청 본문의 형식이 잘못된 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "잘못된 요청 (비밀번호 입력) 예시", value = """
+                                    {
+                                        "title": "유효하지 않은 입력값",
+                                        "status": 400,
+                                        "detail": "password: 비밀번호는 6~20자 길이의 영문, 숫자, 특수문자만 사용할 수 있습니다.",
+                                        "instance": "/api/auth/signup"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "401", description = "요청에 포함된 세션(JSESSIONID)이 없거나 만료되어, 세종대 학생 인증 상태를 확인할 수 없는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "세종대학교 인증 정보 없음 또는 만료 예시", value = """
+                                    {
+                                        "title": "세종대학교 인증 필요",
+                                        "status": 401,
+                                        "detail": "세종대학교 인증이 만료되었거나, 아직 인증하지 않았습니다.",
+                                        "instance": "/api/auth/signup"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+    })
+    ResponseEntity<SignupResponse> signup(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "줍줍 회원 가입 요청",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = SignupRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "정상 요청 예시",
+                                            value = """
+                                                {
+                                                    "studentId": 20011111,
+                                                    "password": "asdasda@123"
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ) @RequestBody @Valid SignupRequest signupRequest,
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) HttpServletResponse response
+    );
+
+
+
+    @Operation(summary = "줍줍 로그인",
+            description = "줍줍 아이디와 비밀번호를 사용하여 로그인합니다. 성공 시, Access Token이 쿠키에 설정됩니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인에 성공하고, access_token이 쿠키에 정상적으로 설정된 경우",
+                    content = @Content(schema = @Schema(implementation = LoginResponse.class),
+                            examples = @ExampleObject(name = "줍줍 로그인 성공 예시", value = """
+                                    {
+                                        "memberId": 2,
+                                        "message": "로그인에 성공했습니다."
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "400", description = "요청 본문의 studentId 또는 password가 누락된 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "잘못된 요청 본문 (body) 예시", value = """
+                                    {
+                                        "title": "잘못된 요청 본문",
+                                        "status": 400,
+                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
+                                        "instance": "/api/auth/login"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "401", description = "존재하지 않는 studentId로 로그인을 시도했거나, password가 일치하지 않는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "줍줍 로그인 실패 예시", value = """
+                                    {
+                                        "title": "로그인 실패",
+                                        "status": 401,
+                                        "detail": "아이디 또는 패스워드가 일치하지 않습니다.",
+                                        "instance": "/api/auth/login"
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<LoginResponse> login(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "줍줍 로그인 가입 요청",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = LoginRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "정상 요청 예시",
+                                            value = """
+                                                {
+                                                    "studentId": 20011111,
+                                                    "password": "asdasda@123"
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ) @RequestBody @Valid LoginRequest loginRequest,
+            @Parameter(hidden = true) HttpServletResponse response
+    );
+
+
+
+
+    @Operation(summary = "로그아웃",
+            description = "사용자를 로그아웃 처리하고, 저장된 억세스 토큰(쿠키)을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 포함된 access_token 쿠키가 성공적으로 만료(삭제) 처리된 경우")
+    })
+    ResponseEntity<Void> logout(@Parameter(hidden = true) HttpServletResponse response);
+
+
+
+
+    @Operation(summary = "포털 로그인 (데모용)",
+            description = "세종대학교 포털 인증과 로그인을 동시에 처리합니다. 기존 회원은 로그인 처리되며, 신규 회원은 자동 가입 후 로그인됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "포털 인증에 성공하고, 줍줍 서비스 access_token이 쿠키에 설정된 경우",
+                    content = @Content(schema = @Schema(implementation = LoginResponse.class),
+                            examples = @ExampleObject(name = "포털 로그인으로 즉시 줍줍 로그인 성공 예시", value = """
+                                    {
+                                        "memberId": 2,
+                                        "message": "로그인에 성공했습니다."
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 본문의 portalId 또는 portalPassword가 누락되었거나 형식이 올바르지 않은 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "잘못된 요청 본문 (body) 예시", value = """
+                                    {
+                                        "title": "잘못된 요청 본문",
+                                        "status": 400,
+                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
+                                        "instance": "/api/auth/login/portal"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "제출된 portalId와 portalPassword가 실제 포털 정보와 일치하지 않아 인증에 실패한 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "포털 로그인 실패 예시", value = """
+                                    {
+                                        "title": "세종대학교 포털 로그인 실패",
+                                        "status": 401,
+                                        "detail": "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요.",
+                                        "instance": "/api/auth/login/portal"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "409", description = "인증에 성공했으나, 해당 학번으로 이미 서비스에 가입된 회원이 존재하는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "이미 가입된 사용자 예시", value = """
+                                    {
+                                        "title": "가입된 사용자",
+                                        "status": 409,
+                                        "detail": "이미 가입된 사용자 입니다.",
+                                        "instance": "/api/login/portal"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "503", description = "세종대학교 포털 서버 자체의 문제나 네트워크 오류로 인해 인증 시도가 불가능한 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "포털 인증 실패 예시", value = """
+                                    {
+                                        "title": "세종대학교 포털 서버 통신 오류",
+                                        "status": 503,
+                                        "detail": "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+                                        "instance": "/api/auth/login/portal"
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<LoginResponse> portalLogin(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "세종대학교 포털 로그인 요청",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PortalLoginRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "정상 요청 예시",
+                                            value = """
+                                                {
+                                                    "portalId": "2001111 (본인 포탈 로그인 아이디)",
+                                                    "portalPassword": "asdasdasd (본인 포탈 로그인 PW)"
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ) @RequestBody @Valid PortalLoginRequest request,
+            @Parameter(hidden = true) HttpServletResponse response
+    );
+
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/annotation/MemberAuth.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/annotation/MemberAuth.java
@@ -1,0 +1,11 @@
+package com.greedy.zupzup.auth.presentation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberAuth {
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/argumentresolver/LoginMember.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/argumentresolver/LoginMember.java
@@ -1,0 +1,6 @@
+package com.greedy.zupzup.auth.presentation.argumentresolver;
+
+public record LoginMember(
+        Long memberId
+) {
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/argumentresolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.greedy.zupzup.auth.presentation.argumentresolver;
+
+import com.greedy.zupzup.auth.jwt.JwtTokenProvider;
+import com.greedy.zupzup.auth.presentation.annotation.MemberAuth;
+import com.greedy.zupzup.auth.presentation.dto.LoginMember;
+import com.greedy.zupzup.global.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginMember.class) &&
+                parameter.hasParameterAnnotation(MemberAuth.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        LoginMember loginMember = (LoginMember) request.getAttribute("loginMember");
+        if (loginMember != null) {
+            return loginMember;
+        }
+
+        return getLoginMemberFromAccessToken(request);
+    }
+
+    private LoginMember getLoginMemberFromAccessToken(HttpServletRequest request) {
+        String accessToken = CookieUtil.extractToken(request.getCookies());
+        Long loginMemberId = jwtTokenProvider.getLoginMemberId(accessToken);
+        return new LoginMember(loginMemberId);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/argumentresolver/LoginMemberArgumentResolver.java
@@ -2,7 +2,6 @@ package com.greedy.zupzup.auth.presentation.argumentresolver;
 
 import com.greedy.zupzup.auth.jwt.JwtTokenProvider;
 import com.greedy.zupzup.auth.presentation.annotation.MemberAuth;
-import com.greedy.zupzup.auth.presentation.dto.LoginMember;
 import com.greedy.zupzup.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/LoginMember.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/LoginMember.java
@@ -1,0 +1,6 @@
+package com.greedy.zupzup.auth.presentation.dto;
+
+public record LoginMember(
+        Long memberId
+) {
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/LoginMember.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/LoginMember.java
@@ -1,6 +1,0 @@
-package com.greedy.zupzup.auth.presentation.dto;
-
-public record LoginMember(
-        Long memberId
-) {
-}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/LoginRequest.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.greedy.zupzup.auth.presentation.dto;
+
+import com.greedy.zupzup.auth.application.dto.LoginCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record LoginRequest(
+
+        @NotBlank(message = "줍줍 로그인 학번을 입력해 주세요.")
+        @Pattern(regexp = "[0-9]+", message = "학번은 숫자만 입력 가능합니다.")
+        String studentId,
+
+        @NotBlank(message = "줍줍 로그인 비밀번호를 입력해 주세요.")
+        String password
+) {
+    public LoginCommand toCommand() {
+        return new LoginCommand(
+                Integer.parseInt(studentId),
+                this.password
+        );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/LoginResponse.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/LoginResponse.java
@@ -2,14 +2,14 @@ package com.greedy.zupzup.auth.presentation.dto;
 
 import com.greedy.zupzup.member.domain.Member;
 
-public record SignupResponse(
+public record LoginResponse(
         Long memberId,
         String message
 ) {
-    public static SignupResponse from(Member member) {
-        return new SignupResponse(
+    public static LoginResponse from(Member member) {
+        return new LoginResponse(
                 member.getId(),
-                "회원가입에 성공했습니다!"
+                "로그인에 성공했습니다."
         );
     }
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/PortalLoginRequest.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/PortalLoginRequest.java
@@ -1,0 +1,17 @@
+package com.greedy.zupzup.auth.presentation.dto;
+
+import com.greedy.zupzup.auth.application.dto.PortalLoginCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record PortalLoginRequest(
+
+        @NotBlank(message = "세종대학교 포털 로그인 학번을 입력해 주세요.")
+        String portalId,
+
+        @NotBlank(message = "세종대학교 포털 로그인 비밀번호를 입력해 주세요.")
+        String portalPassword
+) {
+    public PortalLoginCommand toCommand() {
+        return new PortalLoginCommand(this.portalId(), this.portalPassword());
+    }
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/PortalLoginRequest.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/PortalLoginRequest.java
@@ -12,6 +12,6 @@ public record PortalLoginRequest(
         String portalPassword
 ) {
     public PortalLoginCommand toCommand() {
-        return new PortalLoginCommand(this.portalId(), this.portalPassword());
+        return new PortalLoginCommand(this.portalId, this.portalPassword);
     }
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/SignupRequest.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/SignupRequest.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.Pattern;
 public record SignupRequest(
 
         @NotNull(message = "학번은 필수입니다.")
-        int studentId,
+        Integer studentId,
 
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Pattern(

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/SignupRequest.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/SignupRequest.java
@@ -1,0 +1,31 @@
+package com.greedy.zupzup.auth.presentation.dto;
+
+import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.application.dto.SignupCommand;
+import jakarta.validation.constraints.NotBlank;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+
+public record SignupRequest(
+
+        @NotNull(message = "학번은 필수입니다.")
+        int studentId,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^[A-Za-z\\d~!@#$%^&*()_+\\-=\\[\\]{}|;:'\",.<>/?]{6,20}$",
+                message = "비밀번호는 6~20자 길이의 영문, 숫자, 특수문자만 사용할 수 있습니다."
+        )
+        String password
+) {
+
+    public SignupCommand toCommand(SejongAuthInfo sejongAuthInfo) {
+        return new SignupCommand(
+                sejongAuthInfo,
+                this.studentId,
+                this.password
+        );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/SignupResponse.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/SignupResponse.java
@@ -1,0 +1,15 @@
+package com.greedy.zupzup.auth.presentation.dto;
+
+import com.greedy.zupzup.member.domain.Member;
+
+public record SignupResponse(
+        Long memberId,
+        String message
+) {
+    public static SignupResponse of(Member member) {
+        return new SignupResponse(
+                member.getId(),
+                "회원가입에 성공했습니다!"
+        );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/VerifiedStudentResponse.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/VerifiedStudentResponse.java
@@ -1,0 +1,10 @@
+package com.greedy.zupzup.auth.presentation.dto;
+
+public record VerifiedStudentResponse(
+        int studentId,
+        String message
+) {
+    public static VerifiedStudentResponse from(int studentId) {
+        return new VerifiedStudentResponse(studentId, "세종대학교 학생 인증에 성공했습니다.");
+    }
+}

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/VerifiedStudentResponse.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/VerifiedStudentResponse.java
@@ -1,10 +1,10 @@
 package com.greedy.zupzup.auth.presentation.dto;
 
 public record VerifiedStudentResponse(
-        int studentId,
+        Integer studentId,
         String message
 ) {
-    public static VerifiedStudentResponse from(int studentId) {
+    public static VerifiedStudentResponse from(Integer studentId) {
         return new VerifiedStudentResponse(studentId, "세종대학교 학생 인증에 성공했습니다.");
     }
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/dto/VerifiedStudentResponse.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/dto/VerifiedStudentResponse.java
@@ -5,6 +5,6 @@ public record VerifiedStudentResponse(
         String message
 ) {
     public static VerifiedStudentResponse from(Integer studentId) {
-        return new VerifiedStudentResponse(studentId, "세종대학교 학생 인증에 성공했습니다.");
+        return new VerifiedStudentResponse(studentId, "세종대학교 인증에 성공했습니다.");
     }
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/interceptor/AuthInterceptor.java
@@ -1,7 +1,7 @@
 package com.greedy.zupzup.auth.presentation.interceptor;
 
 import com.greedy.zupzup.auth.jwt.JwtTokenProvider;
-import com.greedy.zupzup.auth.presentation.dto.LoginMember;
+import com.greedy.zupzup.auth.presentation.argumentresolver.LoginMember;
 import com.greedy.zupzup.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/greedy/zupzup/auth/presentation/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/interceptor/AuthInterceptor.java
@@ -1,0 +1,26 @@
+package com.greedy.zupzup.auth.presentation.interceptor;
+
+import com.greedy.zupzup.auth.jwt.JwtTokenProvider;
+import com.greedy.zupzup.auth.presentation.dto.LoginMember;
+import com.greedy.zupzup.global.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String accessToken = CookieUtil.extractToken(request.getCookies());
+        Long loginMemberId = jwtTokenProvider.getLoginMemberId(accessToken);
+        LoginMember loginMember = new LoginMember(loginMemberId);
+        request.setAttribute("loginMember", loginMember);
+        return loginMemberId != null;
+    }
+}

--- a/src/main/java/com/greedy/zupzup/global/config/HttpClientConfig.java
+++ b/src/main/java/com/greedy/zupzup/global/config/HttpClientConfig.java
@@ -1,0 +1,63 @@
+package com.greedy.zupzup.global.config;
+
+import com.greedy.zupzup.auth.exception.AuthException;
+import com.greedy.zupzup.global.exception.InfrastructureException;
+import okhttp3.JavaNetCookieJar;
+import okhttp3.OkHttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.net.ssl.*;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+
+@Configuration
+public class HttpClientConfig {
+
+    /**
+     * 세종대학교 포털 로그인을 요청을 위한 OkHttpClient 객체를 생성합니다.
+     */
+    @Bean
+    public OkHttpClient buildClient() {
+        try {
+            // SSLContext 생성, 모든 인증서 신뢰 설정
+            SSLContext sslCtx = SSLContext.getInstance("SSL");
+            sslCtx.init(null, new TrustManager[]{trustAllManager()}, new java.security.SecureRandom());
+            SSLSocketFactory sslFactory = sslCtx.getSocketFactory();
+
+            // hostnameVerifier: 모든 호스트네임에 대해 OK 처리
+            HostnameVerifier hostnameVerifier = (hostname, session) -> true;
+
+            // 쿠키 관리
+            CookieManager cookieManager = new CookieManager();
+            cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+
+            // OkHttpClient 생성
+            return new OkHttpClient.Builder()
+                    .sslSocketFactory(sslFactory, trustAllManager())
+                    .hostnameVerifier(hostnameVerifier)
+                    .cookieJar(new JavaNetCookieJar(cookieManager))
+                    .build();
+
+        } catch (Exception e) {
+            throw new InfrastructureException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
+        }
+    }
+
+    private X509TrustManager trustAllManager() {
+        return new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                return new java.security.cert.X509Certificate[0];
+            }
+        };
+    }
+}

--- a/src/main/java/com/greedy/zupzup/global/config/S3Config.java
+++ b/src/main/java/com/greedy/zupzup/global/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.greedy.zupzup.global.infrastructure;
+package com.greedy.zupzup.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/greedy/zupzup/global/config/SwaggerConfig.java
+++ b/src/main/java/com/greedy/zupzup/global/config/SwaggerConfig.java
@@ -20,18 +20,29 @@ public class SwaggerConfig {
                         #### [Github](https://github.com/greedy-team/zup-zup-be.git)""")
                 .version("v1.0.0");
 
-        String jwtSchemeName = "Bearer Token";
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // 1. 세션 쿠키 인증(JSESSIONID)을 위한 SecurityScheme 설정 (세종대학교 인증 시)
+        String sessionIdSchemeName = "sejongSessionAuth";
+
+        // 2. Access Token 쿠키 인증을 위한 SecurityScheme 설정 (줍줍 서비스 인증 시)
+        String accessTokenSchemeName = "zupzupAccessTokenAuth";
+
+
         Components components = new Components()
-                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
-                        .name(jwtSchemeName)
-                        .type(SecurityScheme.Type.HTTP)
-                        .scheme("bearer")
-                        .bearerFormat("JWT"));
+                .addSecuritySchemes(sessionIdSchemeName, new SecurityScheme()
+                        .name("JSESSIONID")
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.COOKIE)
+                        .description("세종대학교 학생 인증 성공 후 발급되는 세션 쿠키"))
+
+                .addSecuritySchemes(accessTokenSchemeName, new SecurityScheme()
+                        .name("access_token")
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.COOKIE)
+                        .description("서비스 로그인 성공 후 발급되는 Access Token 쿠키"));
+
 
         return new OpenAPI()
                 .info(info)
-                .addSecurityItem(securityRequirement)
                 .components(components);
     }
 }

--- a/src/main/java/com/greedy/zupzup/global/config/SwaggerConfig.java
+++ b/src/main/java/com/greedy/zupzup/global/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.greedy.zupzup.global.infrastructure;
+package com.greedy.zupzup.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/com/greedy/zupzup/global/config/WebConfig.java
+++ b/src/main/java/com/greedy/zupzup/global/config/WebConfig.java
@@ -1,0 +1,38 @@
+package com.greedy.zupzup.global.config;
+
+import com.greedy.zupzup.auth.presentation.argumentresolver.LoginMemberArgumentResolver;
+import com.greedy.zupzup.auth.presentation.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns(
+                        "/api/auth/**",
+                        "/api/lost-items/summary",
+                        "/api/lost-items",
+                        "/api/lost-items/*",
+                        "/api/school-areas/**",
+                        "/api/categories/**"
+                );
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
+++ b/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
@@ -24,7 +24,6 @@ public class CookieUtil {
         }
         for (Cookie cookie : cookies) {
             if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
-                System.out.println("쿠키 값 " + cookie.getValue());
                 return cookie.getValue();
             }
         }

--- a/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
+++ b/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
@@ -4,18 +4,22 @@ import com.greedy.zupzup.auth.exception.AuthException;
 import com.greedy.zupzup.global.exception.ApplicationException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
 
 public class CookieUtil {
 
     private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
 
     public static void setToken(String accessToken, int cookieExpirationSeconds, HttpServletResponse response) {
-        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(cookieExpirationSeconds);
-        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(cookieExpirationSeconds)
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
     public static String extractToken(Cookie[] cookies) {

--- a/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
+++ b/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
@@ -1,0 +1,30 @@
+package com.greedy.zupzup.global.util;
+
+import com.greedy.zupzup.auth.exception.AuthException;
+import com.greedy.zupzup.global.exception.ApplicationException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    public static void setToken(String accessToken, int cookieExpirationSeconds, HttpServletResponse response) {
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(cookieExpirationSeconds);
+        response.addCookie(cookie);
+    }
+
+    public static String extractToken(Cookie[] cookies) {
+        if (cookies == null) {
+            throw new ApplicationException(AuthException.UNAUTHENTICATED_REQUEST);
+        }
+        for (Cookie cookie : cookies) {
+            if ("accessToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        throw new ApplicationException(AuthException.UNAUTHENTICATED_REQUEST);
+    }
+}

--- a/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
+++ b/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
@@ -7,8 +7,10 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class CookieUtil {
 
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+
     public static void setToken(String accessToken, int cookieExpirationSeconds, HttpServletResponse response) {
-        Cookie cookie = new Cookie("accessToken", accessToken);
+        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
@@ -21,7 +23,8 @@ public class CookieUtil {
             throw new ApplicationException(AuthException.UNAUTHENTICATED_REQUEST);
         }
         for (Cookie cookie : cookies) {
-            if ("accessToken".equals(cookie.getName())) {
+            if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                System.out.println("쿠키 값 " + cookie.getValue());
                 return cookie.getValue();
             }
         }

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemController.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemController.java
@@ -31,8 +31,4 @@ public class LostItemController {
                 .body(new LostItemRegisterResponse(lostItem.getId(), "분실물 등록에 성공했습니다."));
     }
 
-    @GetMapping("/test/hello")
-    public ResponseEntity<LoginMember> hello(@MemberAuth LoginMember loginMember) {
-        return ResponseEntity.ok(loginMember);
-    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemController.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemController.java
@@ -1,5 +1,7 @@
 package com.greedy.zupzup.lostitem.presentation;
 
+import com.greedy.zupzup.auth.presentation.annotation.MemberAuth;
+import com.greedy.zupzup.auth.presentation.argumentresolver.LoginMember;
 import com.greedy.zupzup.lostitem.application.LostItemRegisterService;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.presentation.dto.LostItemRegisterRequest;
@@ -7,10 +9,7 @@ import com.greedy.zupzup.lostitem.presentation.dto.LostItemRegisterResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URI;
@@ -30,5 +29,10 @@ public class LostItemController {
         return ResponseEntity
                 .created(URI.create("/api/lost-items/" + lostItem.getId()))
                 .body(new LostItemRegisterResponse(lostItem.getId(), "분실물 등록에 성공했습니다."));
+    }
+
+    @GetMapping("/test/hello")
+    public ResponseEntity<LoginMember> hello(@MemberAuth LoginMember loginMember) {
+        return ResponseEntity.ok(loginMember);
     }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemDetailViewController.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemDetailViewController.java
@@ -18,7 +18,7 @@ public class LostItemDetailViewController {
 
     private final LostItemDetailViewService service;
 
-    @GetMapping("/{lostItemId}")
+    @GetMapping("/{lostItemId}/detail")
     public ResponseEntity<LostItemDetailViewResponse> getDetail(@PathVariable Long lostItemId,
                                                                 @RequestParam Long memberId) {
         LostItemDetailViewCommand cmd = service.getDetail(lostItemId, memberId);

--- a/src/main/java/com/greedy/zupzup/member/domain/Member.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.greedy.zupzup.member.domain;
 
+import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
 import com.greedy.zupzup.global.BaseTimeEntity;
 import lombok.*;
 import jakarta.persistence.*;
@@ -27,9 +28,4 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private Role role = Role.USER;
 
-
-    public Member(String name, Integer studentId) {
-        this.name = name;
-        this.studentId = studentId;
-    }
 }

--- a/src/main/java/com/greedy/zupzup/member/domain/Member.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Member.java
@@ -5,8 +5,6 @@ import lombok.*;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "member",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -17,22 +15,16 @@ public class Member extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String email;
+    private String name;
 
-    @Column(nullable = false)
-    private String nickname;
+    @Column(unique = true, nullable = false)
+    private String studentId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Provider provider;
-
-    @Column(nullable = false)
-    private String providerId;
+    // 일단은 nullable로 -> 추후 사이트 로그인 방식으로 바뀌면 가입 유도
+    private String password;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
 
-    @Column(nullable = false)
-    private boolean emailConsent;
 }

--- a/src/main/java/com/greedy/zupzup/member/domain/Member.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Member.java
@@ -18,7 +18,7 @@ public class Member extends BaseTimeEntity {
     private String name;
 
     @Column(unique = true, nullable = false)
-    private String studentId;
+    private Integer studentId;
 
     // 일단은 nullable로 -> 추후 사이트 로그인 방식으로 바뀌면 가입 유도
     private String password;
@@ -28,7 +28,7 @@ public class Member extends BaseTimeEntity {
     private Role role = Role.USER;
 
 
-    public Member(String name, String studentId) {
+    public Member(String name, Integer studentId) {
         this.name = name;
         this.studentId = studentId;
     }

--- a/src/main/java/com/greedy/zupzup/member/domain/Member.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Member.java
@@ -1,6 +1,5 @@
 package com.greedy.zupzup.member.domain;
 
-import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
 import com.greedy.zupzup.global.BaseTimeEntity;
 import lombok.*;
 import jakarta.persistence.*;

--- a/src/main/java/com/greedy/zupzup/member/domain/Member.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Member.java
@@ -25,6 +25,11 @@ public class Member extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role;
+    private Role role = Role.USER;
 
+
+    public Member(String name, String studentId) {
+        this.name = name;
+        this.studentId = studentId;
+    }
 }

--- a/src/main/java/com/greedy/zupzup/member/domain/Provider.java
+++ b/src/main/java/com/greedy/zupzup/member/domain/Provider.java
@@ -1,6 +1,0 @@
-package com.greedy.zupzup.member.domain;
-
-public enum Provider {
-    GOOGLE,
-    NAVER
-}

--- a/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
+++ b/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByStudentId(String studentId);
+    Optional<Member> findByStudentId(Integer studentId);
 
     default Member getById(Long id) {
         return findById(id)

--- a/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
+++ b/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
@@ -5,7 +5,11 @@ import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.member.exception.MemberException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByStudentId(String studentId);
 
     default Member getById(Long id) {
         return findById(id)

--- a/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
+++ b/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
@@ -17,4 +17,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         return findById(id)
                 .orElseThrow(() -> new ApplicationException(MemberException.MEMBER_NOT_FOUND));
     }
+
+    default Member getMemberByStudentId(Integer studentId) {
+        return findByStudentId(studentId)
+                .orElseThrow(() -> new ApplicationException(MemberException.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
+++ b/src/main/java/com/greedy/zupzup/member/repository/MemberRepository.java
@@ -11,6 +11,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByStudentId(Integer studentId);
 
+    Boolean existsByStudentId(Integer studentId);
+
     default Member getById(Long id) {
         return findById(id)
                 .orElseThrow(() -> new ApplicationException(MemberException.MEMBER_NOT_FOUND));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,10 @@ springdoc:
   swagger-ui.display-request-duration: true
   swagger-ui:
     path: /docs/swagger
+
+zupzup:
+  auth:
+    jwt:
+      access:
+        secret: ${ACCESS_JWT_SECRET_KEY:accessQWTGSDGASDFQWFQWAFSF}
+        expiration: ${ACCESS_TOKEN_EXPIRATION:60000}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,11 +24,9 @@ springdoc:
   swagger-ui:
     path: /docs/swagger
 
-
-
 zupzup:
   auth:
     jwt:
       access:
-        secret: ${ACCESS_JWT_SECRET_KEY:accessQWTGSDGASDFQWFQWAFSF}
-        expiration: ${ACCESS_TOKEN_EXPIRATION:60000}
+        secret: ${ACCESS_JWT_SECRET_KEY:accessFSFvPh5v9x3w+T8fA9gB7eC6dF3gH5jJ2kL4mN1oP0rS1c}
+        expiration-second: ${ACCESS_TOKEN_EXPIRATION:6000}  # 초 단위

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 8080
 
+  servlet:
+    session:
+      timeout: ${STUDENT_VERIFICATION_SESSION_TIME:1m}
+
 cloud:
   aws:
     credentials:
@@ -19,6 +23,8 @@ springdoc:
   swagger-ui.display-request-duration: true
   swagger-ui:
     path: /docs/swagger
+
+
 
 zupzup:
   auth:

--- a/src/test/java/com/greedy/zupzup/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/auth/application/AuthServiceTest.java
@@ -1,0 +1,273 @@
+package com.greedy.zupzup.auth.application;
+
+import com.greedy.zupzup.auth.application.dto.LoginCommand;
+import com.greedy.zupzup.auth.application.dto.PortalLoginCommand;
+import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.application.dto.SignupCommand;
+import com.greedy.zupzup.auth.exception.AuthException;
+import com.greedy.zupzup.auth.infrastructure.PasswordEncoder;
+import com.greedy.zupzup.auth.infrastructure.SejongAuthenticator;
+import com.greedy.zupzup.common.ServiceUnitTest;
+import com.greedy.zupzup.common.fixture.MemberFixture;
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+class AuthServiceTest extends ServiceUnitTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private SejongAuthenticator sejongAuthenticator;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+
+    @Nested
+    @DisplayName("세종대학교 인증")
+    class VerifyStudent {
+
+        @Test
+        void 세종대학교_인증에_성공하면_인증된_학번과_이름을_반환해야_한다() {
+            // given
+            PortalLoginCommand command = new PortalLoginCommand("12345678", "portalPw");
+            SejongAuthInfo authInfo = new SejongAuthInfo(12345678, "김세종");
+
+            when(sejongAuthenticator.getStudentAuthInfo(anyString(), anyString())).thenReturn(authInfo);
+            when(memberRepository.existsByStudentId(authInfo.studentId())).thenReturn(false);
+
+            // when
+            SejongAuthInfo result = authService.verifyStudent(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.studentId()).isEqualTo(authInfo.studentId());
+                softly.assertThat(result.studentName()).isEqualTo(authInfo.studentName());
+            });
+
+            then(sejongAuthenticator).should().getStudentAuthInfo(anyString(), anyString());
+            then(memberRepository).should().existsByStudentId(anyInt());
+        }
+
+        @Test
+        void 이미_가입된_학번으로_인증을_하면_예외가_발생해야_한다() {
+            // given
+            PortalLoginCommand command = new PortalLoginCommand("12345678", "portalPw");
+            SejongAuthInfo authInfo = new SejongAuthInfo(12345678, "김세종");
+
+            when(sejongAuthenticator.getStudentAuthInfo(anyString(), anyString())).thenReturn(authInfo);
+            when(memberRepository.existsByStudentId(authInfo.studentId())).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifyStudent(command))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(AuthException.ALREADY_REGISTERED_MEMBER.getDetail());
+
+
+            then(sejongAuthenticator).should().getStudentAuthInfo(anyString(), anyString());
+            then(memberRepository).should().existsByStudentId(anyInt());
+        }
+    }
+
+
+    @Nested
+    @DisplayName("회원 가입")
+    class Signup {
+
+        @Test
+        public void 회원_가입에_성공하면_회원정보를_저장하고_가입된_멤버_객체를_반환해야_한다() throws Exception {
+            // given
+            Member signupMember = MemberFixture.MEMBER();
+            SejongAuthInfo authInfo = new SejongAuthInfo(signupMember.getStudentId(), signupMember.getName());
+            SignupCommand command = new SignupCommand(authInfo, signupMember.getStudentId(), signupMember.getPassword());
+
+            when(memberRepository.save(any(Member.class))).thenReturn(signupMember);
+            when(passwordEncoder.encode(command.password())).thenReturn("hashedPassword");
+
+            // when
+            Member newMember = authService.signup(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(newMember.getName()).isEqualTo(signupMember.getName());
+                softly.assertThat(newMember.getPassword()).isEqualTo("hashedPassword");
+                softly.assertThat(newMember.getStudentId()).isEqualTo(signupMember.getStudentId());
+            });
+            then(memberRepository).should().save(any(Member.class));
+            then(passwordEncoder).should().encode(command.password());
+        }
+
+        @Test
+        public void 이미_가입된_학번으로_회원가입을_하면_예외가_발생해야_한다() {
+            // given
+            Member signupMember = MemberFixture.MEMBER();
+            SejongAuthInfo authInfo = new SejongAuthInfo(signupMember.getStudentId(), signupMember.getName());
+            SignupCommand command = new SignupCommand(authInfo, signupMember.getStudentId(), signupMember.getPassword());
+
+            when(memberRepository.save(any(Member.class))).thenThrow(DataIntegrityViolationException.class);
+            when(passwordEncoder.encode(command.password())).thenReturn("hashedPassword");
+
+            // when & then
+            assertThatThrownBy(() -> authService.signup(command))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(AuthException.ALREADY_REGISTERED_MEMBER.getDetail());
+            then(memberRepository).should().save(any(Member.class));
+            then(passwordEncoder).should().encode(command.password());
+        }
+
+        @Test
+        void 인증된_학번과_가입_요청된_학번이_다르면_예외가_발생해야_한다() {
+            // given
+            SejongAuthInfo authInfo = new SejongAuthInfo(12345678, "김세종");
+            SignupCommand command = new SignupCommand(authInfo, 87654321, "password");
+
+            // when
+            assertThatThrownBy(() -> authService.signup(command))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(AuthException.STUDENT_ID_MISMATCH.getDetail());
+
+            // then
+            then(memberRepository).should(never()).save(any(Member.class));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("로그인")
+    class Login {
+
+        @Test
+        void 회원_로그인에_성공하면_멤버_객체를_반환해야_한다() {
+            // given
+            Member member = MemberFixture.MEMBER();
+            ReflectionTestUtils.setField(member, "id", 1L);
+            LoginCommand loginCommand = new LoginCommand(member.getStudentId(), member.getPassword());
+
+            when(memberRepository.findByStudentId(member.getStudentId())).thenReturn(Optional.of(member));
+            when(passwordEncoder.matches(loginCommand.password(), member.getPassword())).thenReturn(true);
+
+            // when
+            Member loginMember = authService.login(loginCommand);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(loginMember.getId()).isEqualTo(1L);
+                softly.assertThat(loginMember.getName()).isEqualTo(member.getName());
+                softly.assertThat(loginMember.getPassword()).isEqualTo(member.getPassword());
+            });
+            then(memberRepository).should().findByStudentId(member.getStudentId());
+            then(passwordEncoder).should().matches(loginCommand.password(), member.getPassword());
+        }
+
+        @Test
+        public void 주어진_아이디에_대해_가입된_학번이_없으면_예외가_발생해야_한다() {
+            // given
+            Member member = MemberFixture.MEMBER();
+            ReflectionTestUtils.setField(member, "id", 1L);
+            LoginCommand loginCommand = new LoginCommand(member.getStudentId(), member.getPassword());
+
+            when(memberRepository.findByStudentId(member.getStudentId())).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(loginCommand))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(AuthException.LOGIN_FAILED.getDetail());
+            then(memberRepository).should().findByStudentId(member.getStudentId());
+            then(passwordEncoder).should(never()).matches(anyString(), anyString());
+        }
+
+        @Test
+        public void 아이디와_비밀번호가_일차하지_않으면_예외가_발생해야_한다() {
+            // given
+            String password = "zupzup123";
+            Member member = MemberFixture.MEMBER_WITH_ENCODED_PASSWORD(password);
+            ReflectionTestUtils.setField(member, "id", 1L);
+            LoginCommand loginCommand = new LoginCommand(member.getStudentId(), "incorrectPassword");
+
+            when(memberRepository.findByStudentId(member.getStudentId())).thenReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(loginCommand))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(AuthException.LOGIN_FAILED.getDetail());
+            then(memberRepository).should().findByStudentId(member.getStudentId());
+            then(passwordEncoder).should().matches(loginCommand.password(), member.getPassword());
+        }
+    }
+
+
+    @Nested
+    @DisplayName("세종대학교 인증 + 로그인")
+    class AuthenticateSejongAndLogin {
+
+        @Test
+        void 세종대학교_인증에_성공하면_회원정보를_저장하고_가입된_멤버_객체를_반환해야_한다() {
+            // given
+            Member member = MemberFixture.MEMBER();
+            ReflectionTestUtils.setField(member, "id", 1L);
+            PortalLoginCommand command = new PortalLoginCommand(String.valueOf(member.getStudentId()),  "portalPw");
+            SejongAuthInfo authInfo = new SejongAuthInfo(member.getStudentId(), member.getName());
+
+            when(sejongAuthenticator.getStudentAuthInfo(command.portalId(), command.portalPassword())).thenReturn(authInfo);
+            when(memberRepository.findByStudentId(authInfo.studentId())).thenReturn(Optional.empty());
+            when(memberRepository.save(any(Member.class))).thenReturn(member);
+
+            // when
+            Member loginMember = authService.authenticateSejongAndLogin(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(loginMember.getId()).isEqualTo(1L);
+                softly.assertThat(loginMember.getName()).isEqualTo(member.getName());
+                softly.assertThat(loginMember.getStudentId()).isEqualTo(member.getStudentId());
+            });
+            then(memberRepository).should().findByStudentId(member.getStudentId());
+            then(memberRepository).should().save(any(Member.class));
+            then(sejongAuthenticator).should().getStudentAuthInfo(command.portalId(), command.portalPassword());
+        }
+
+        @Test
+        void 이미_가입된_학번이_존재하면_회원정보를_저장하지_않고_가입된_멤버_객체를_반환해야_한다() {
+            // given
+            Member member = MemberFixture.MEMBER();
+            ReflectionTestUtils.setField(member, "id", 1L);
+            PortalLoginCommand command = new PortalLoginCommand(String.valueOf(member.getStudentId()),  "portalPw");
+            SejongAuthInfo authInfo = new SejongAuthInfo(member.getStudentId(), member.getName());
+
+            when(sejongAuthenticator.getStudentAuthInfo(command.portalId(), command.portalPassword())).thenReturn(authInfo);
+            when(memberRepository.findByStudentId(authInfo.studentId())).thenReturn(Optional.of(member));
+
+            // when
+            Member loginMember = authService.authenticateSejongAndLogin(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(loginMember.getId()).isEqualTo(1L);
+                softly.assertThat(loginMember.getName()).isEqualTo(member.getName());
+                softly.assertThat(loginMember.getStudentId()).isEqualTo(member.getStudentId());
+            });
+            then(memberRepository).should().findByStudentId(member.getStudentId());
+            then(memberRepository).should(never()).save(any(Member.class));
+            then(sejongAuthenticator).should().getStudentAuthInfo(command.portalId(), command.portalPassword());
+        }
+
+    }
+
+}

--- a/src/test/java/com/greedy/zupzup/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,555 @@
+package com.greedy.zupzup.auth.presentation;
+
+import com.greedy.zupzup.auth.application.dto.SejongAuthInfo;
+import com.greedy.zupzup.auth.exception.AuthException;
+import com.greedy.zupzup.auth.infrastructure.SejongAuthenticator;
+import com.greedy.zupzup.auth.presentation.dto.*;
+import com.greedy.zupzup.common.ControllerTest;
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.global.exception.CommonException;
+import com.greedy.zupzup.global.exception.ErrorResponse;
+import com.greedy.zupzup.member.domain.Member;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.Mockito.when;
+
+class AuthControllerTest extends ControllerTest {
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+    private static final String SEJONG_VERIFICATION_SESSION_COOKIE_NAME = "JSESSIONID";
+
+
+    @MockitoBean
+    private SejongAuthenticator sejongAuthenticator;
+
+    @Nested
+    @DisplayName("세종대학교 인증 API")
+    class VerifySejong {
+
+        @Test
+        void 세종대학교_인증에_성공하면_인증_정보가_세션에_저장되고_인증된_학번을_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            String portalPw = "portalPw";
+            SejongAuthInfo authInfo = new SejongAuthInfo(studentId, "김세종");
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenReturn(authInfo);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/verify-sejong")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            VerifiedStudentResponse response = extract.as(VerifiedStudentResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
+                softly.assertThat(response.studentId()).isEqualTo(studentId);
+                softly.assertThat(response.message()).isEqualTo("세종대학교 인증에 성공했습니다.");
+                softly.assertThat(extract.cookie(SEJONG_VERIFICATION_SESSION_COOKIE_NAME)).isNotNull();
+            });
+        }
+        
+        @Test
+        void 잘못된_세종대학교_포털_로그인_정보로_인증하면_401_UNAUTHORIZED을_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            String portalPw = "portalPw";
+            ApplicationException exceptionToThrow = new ApplicationException(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW);
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenThrow(exceptionToThrow);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+            
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/verify-sejong")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(401);
+                softly.assertThat(response.title()).isEqualTo(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW.getTitle());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW.getDetail());
+                softly.assertThat(response.status()).isEqualTo(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW.getHttpStatus().value());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/verify-sejong");
+            });
+        }
+        
+        @Test
+        void 인증에_성공했으나_해당_학번으로_이미_가입된_회원이_존재하는_경우에는_409_CONFLICT를_응답해야_한다() {
+            // given
+            String password = "password";
+            Member givenMember = givenMember(password);
+
+            Integer studentId = givenMember.getStudentId();   // 이미 가입된 멤버와 같은 학번으로 인증 요청
+            String portalPw = "portalPw";
+            SejongAuthInfo authInfo = new SejongAuthInfo(studentId, givenMember.getName());
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenReturn(authInfo);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+            
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/verify-sejong")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(409);
+                softly.assertThat(response.title()).isEqualTo(AuthException.ALREADY_REGISTERED_MEMBER.getTitle());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.ALREADY_REGISTERED_MEMBER.getDetail());
+                softly.assertThat(response.status()).isEqualTo(AuthException.ALREADY_REGISTERED_MEMBER.getHttpStatus().value());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/verify-sejong");
+            });
+        }
+
+        @Test
+        void 세종대학교_포털_로그인_서버와_통신_오류가_발생하면_503_SERVICE_UNAVAILABLE을_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            String portalPw = "portalPw";
+            ApplicationException exceptionToThrow = new ApplicationException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenThrow(exceptionToThrow);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/verify-sejong")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(503);
+                softly.assertThat(response.title()).isEqualTo(AuthException.SEJONG_PORTAL_LOGIN_FAILED.getTitle());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.SEJONG_PORTAL_LOGIN_FAILED.getDetail());
+                softly.assertThat(response.status()).isEqualTo(AuthException.SEJONG_PORTAL_LOGIN_FAILED.getHttpStatus().value());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/verify-sejong");
+            });
+        }
+    }
+
+
+    @Nested
+    @DisplayName("회원 가입 API")
+    class Signup {
+
+        @Test
+        void 회원가입에_성공하면_발급된_억세스토큰을_쿠키에_저장하고_201_CREATED와_저장된_멤버_식별자를_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            SignupRequest signupRequest = new SignupRequest(studentId, "password");
+
+            ExtractableResponse<Response> verifiedResponse = verifySejong(studentId);  // 세종대학교 인증
+            String sessionCookie = verifiedResponse.cookie(SEJONG_VERIFICATION_SESSION_COOKIE_NAME);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .cookie(SEJONG_VERIFICATION_SESSION_COOKIE_NAME, sessionCookie) // 세션 쿠키를 포함하여 요청
+                    .body(signupRequest)
+                    .when()
+                    .post("/api/auth/signup")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            SignupResponse response = extract.as(SignupResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(201);
+                softly.assertThat(response.message()).isEqualTo("회원가입에 성공했습니다!");
+                Optional<Member> newMember = memberRepository.findById(response.memberId());
+                softly.assertThat(newMember).isPresent();
+                softly.assertThat(extract.cookie(ACCESS_TOKEN_COOKIE_NAME)).isNotNull();
+            });
+        }
+
+
+        @Test
+        void 입력한_비밀번호가_6_20자_길이의_영문_숫자_특수문자만으로_이루어지지_않은_경우_400_BAD_REQUEST를_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            String password = "asd";
+            SignupRequest signupRequest = new SignupRequest(studentId, password);
+
+            ExtractableResponse<Response> verifiedResponse = verifySejong(studentId);  // 세종대학교 인증
+            String sessionCookie = verifiedResponse.cookie(SEJONG_VERIFICATION_SESSION_COOKIE_NAME);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .cookie(SEJONG_VERIFICATION_SESSION_COOKIE_NAME, sessionCookie) // 세션 쿠키를 포함하여 요청
+                    .body(signupRequest)
+                    .when()
+                    .post("/api/auth/signup")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(400);
+                softly.assertThat(response.title()).isEqualTo(CommonException.INVALID_INPUT_VALUE.getTitle());
+                softly.assertThat(response.status()).isEqualTo(CommonException.INVALID_INPUT_VALUE.getHttpStatus().value());
+                softly.assertThat(response.detail()).contains("비밀번호는 6~20자 길이의 영문, 숫자, 특수문자만 사용할 수 있습니다.");
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/signup");
+            });
+        }
+
+        @Test
+        void 인증된_학번과_가입_요청된_학번이_다르면_400_BAD_REQUEST를_응답해야_한다() {
+            // given
+            Integer signupStudentId = 12345678;
+            Integer verifiedStudentId = 87654321;
+            String password = "password";
+            SignupRequest signupRequest = new SignupRequest(signupStudentId, password);
+
+            ExtractableResponse<Response> verifiedResponse = verifySejong(verifiedStudentId);  // 세종대학교 인증
+            String sessionCookie = verifiedResponse.cookie(SEJONG_VERIFICATION_SESSION_COOKIE_NAME);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .cookie(SEJONG_VERIFICATION_SESSION_COOKIE_NAME, sessionCookie) // 세션 쿠키를 포함하여 요청
+                    .body(signupRequest)
+                    .when()
+                    .post("/api/auth/signup")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(400);
+                softly.assertThat(response.title()).isEqualTo(AuthException.STUDENT_ID_MISMATCH.getTitle());
+                softly.assertThat(response.status()).isEqualTo(AuthException.STUDENT_ID_MISMATCH.getHttpStatus().value());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.STUDENT_ID_MISMATCH.getDetail());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/signup");
+            });
+        }
+
+        @Test
+        public void 세종대학교_인증을_하지_않고_가입_요청을_한_경우에는_401_UNAUTHORIZED을_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            String password = "password";
+            SignupRequest signupRequest = new SignupRequest(studentId, password);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(signupRequest)
+                    .when()
+                    .post("/api/auth/signup")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(401);
+                softly.assertThat(response.title()).isEqualTo(AuthException.SEJONG_VERIFICATION_EXPIRED.getTitle());
+                softly.assertThat(response.status()).isEqualTo(AuthException.SEJONG_VERIFICATION_EXPIRED.getHttpStatus().value());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.SEJONG_VERIFICATION_EXPIRED.getDetail());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/signup");
+            });
+        }
+
+        /**
+         * 세종대학교 인증을 진행하는 헬퍼 메서드
+         */
+        private ExtractableResponse<Response> verifySejong(Integer studentId) {
+
+            String portalPw = "portalPw";
+            SejongAuthInfo authInfo = new SejongAuthInfo(studentId, "김세종");
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenReturn(authInfo);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+
+            return RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/verify-sejong")
+                    .then().log().all()
+                    .extract();
+        }
+    }
+
+
+    @Nested
+    @DisplayName("로그인 API")
+    class Login {
+
+        @Test
+        void 로그인에_성공하면_발급된_억세스토큰을_쿠키에_저장하고_200_OK와_저장된_멤버_식별자를_응답해야_한다() {
+            // given
+            String password = "password";
+            Member member = givenMember(password);
+
+            LoginRequest loginRequest = new LoginRequest(String.valueOf(member.getStudentId()), password);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(loginRequest)
+                    .when()
+                    .post("/api/auth/login")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            LoginResponse response = extract.as(LoginResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
+                softly.assertThat(response.memberId()).isEqualTo(member.getId());
+                softly.assertThat(response.message()).isEqualTo("로그인에 성공했습니다.");
+                softly.assertThat(extract.cookie(ACCESS_TOKEN_COOKIE_NAME)).isNotNull();
+            });
+        }
+
+        @Test
+        public void 가입되지_않은_학번으로_로그인을_요청하면_401_UNAUTHORIZED을_응답해야_한다() {
+            // given
+            LoginRequest loginRequest = new LoginRequest("12345678", "password");
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(loginRequest)
+                    .when()
+                    .post("/api/auth/login")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(401);
+                softly.assertThat(response.title()).isEqualTo(AuthException.LOGIN_FAILED.getTitle());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.LOGIN_FAILED.getDetail());
+                softly.assertThat(response.status()).isEqualTo(AuthException.LOGIN_FAILED.getHttpStatus().value());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/login");
+                softly.assertThat(extract.cookie(ACCESS_TOKEN_COOKIE_NAME)).isNull();
+            });
+        }
+
+        @Test
+        public void 가입되었지만_비밀번호가_일치하지_않으면_401_UNAUTHORIZED을_응답해야_한다() {
+            // given
+            String password = "requestPassword";
+            Member member = givenMember("password");
+
+            LoginRequest loginRequest = new LoginRequest(String.valueOf(member.getStudentId()), password);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(loginRequest)
+                    .when()
+                    .post("/api/auth/login")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(401);
+                softly.assertThat(response.title()).isEqualTo(AuthException.LOGIN_FAILED.getTitle());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.LOGIN_FAILED.getDetail());
+                softly.assertThat(response.status()).isEqualTo(AuthException.LOGIN_FAILED.getHttpStatus().value());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/login");
+                softly.assertThat(extract.cookie(ACCESS_TOKEN_COOKIE_NAME)).isNull();
+            });
+        }
+    }
+
+
+    @Nested
+    @DisplayName("로그아웃 API")
+    class Logout {
+
+        @Test
+        void 로그아웃을_하면_쿠키에_저장된_억세스토큰을_삭제하고_200_OK를_응답해야_한다() {
+            // given
+            Member member = givenMember("password");
+            String accessToken = givenAccessToken(member);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken)
+                    .when()
+                    .post("/api/auth/logout")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
+                softly.assertThat(extract.cookie(ACCESS_TOKEN_COOKIE_NAME)).isEmpty();
+            });
+        }
+    }
+
+
+    @Nested
+    @DisplayName("세종대학교 인증 + 즉시 로그인 API")
+    class PortalLogin {
+
+        @Test
+        void 세종대학교_인증에_성공하면_발급된_억세스토큰을_쿠키에_저장하고_200_OK와_저장된_멤버_식별자를_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            String portalPw = "portalPw";
+            SejongAuthInfo authInfo = new SejongAuthInfo(studentId, "김세종");
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenReturn(authInfo);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/login/portal")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            LoginResponse response = extract.as(LoginResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
+                Optional<Member> loginMember = memberRepository.findByStudentId(studentId);
+                softly.assertThat(response.memberId()).isEqualTo(loginMember.get().getId());
+                softly.assertThat(response.message()).isEqualTo("로그인에 성공했습니다.");
+                softly.assertThat(extract.cookie(ACCESS_TOKEN_COOKIE_NAME)).isNotNull();
+            });
+        }
+
+        @Test
+        void 해당_학번으로_이미_가입된_회원이_존재하는_경우에도_발급된_억세스토큰을_쿠키에_저장하고_200_OK와_저장된_멤버_식별자를_응답해야_한다() {
+            // given
+            String password = "password";
+            Member givenMember = givenMember(password);
+
+            Integer studentId = givenMember.getStudentId();   // 이미 가입된 멤버와 같은 학번으로 포털 로그인 요청
+            String portalPw = "portalPw";
+            SejongAuthInfo authInfo = new SejongAuthInfo(studentId, givenMember.getName());
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenReturn(authInfo);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/login/portal")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            LoginResponse response = extract.as(LoginResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
+                Optional<Member> loginMember = memberRepository.findByStudentId(studentId);
+                softly.assertThat(response.memberId()).isEqualTo(loginMember.get().getId());
+                softly.assertThat(response.message()).isEqualTo("로그인에 성공했습니다.");
+                softly.assertThat(extract.cookie(ACCESS_TOKEN_COOKIE_NAME)).isNotNull();
+            });
+        }
+
+        @Test
+        void 잘못된_세종대학교_포털_로그인_정보로_로그인하면_401_UNAUTHORIZED을_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            String portalPw = "portalPw";
+            ApplicationException exceptionToThrow = new ApplicationException(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW);
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenThrow(exceptionToThrow);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/login/portal")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(401);
+                softly.assertThat(response.title()).isEqualTo(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW.getTitle());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW.getDetail());
+                softly.assertThat(response.status()).isEqualTo(AuthException.INVALID_SEJONG_PORTAL_LOGIN_ID_PW.getHttpStatus().value());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/login/portal");
+            });
+        }
+
+        @Test
+        void 세종대학교_포털_로그인_서버와_통신_오류가_발생하면_503_SERVICE_UNAVAILABLE을_응답해야_한다() {
+            // given
+            Integer studentId = 12345678;
+            String portalPw = "portalPw";
+            ApplicationException exceptionToThrow = new ApplicationException(AuthException.SEJONG_PORTAL_LOGIN_FAILED);
+            when(sejongAuthenticator.getStudentAuthInfo(String.valueOf(studentId), portalPw)).thenThrow(exceptionToThrow);
+
+            PortalLoginRequest verifyRequest = new PortalLoginRequest(String.valueOf(studentId), portalPw);
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(verifyRequest)
+                    .when()
+                    .post("/api/auth/login/portal")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(503);
+                softly.assertThat(response.title()).isEqualTo(AuthException.SEJONG_PORTAL_LOGIN_FAILED.getTitle());
+                softly.assertThat(response.detail()).isEqualTo(AuthException.SEJONG_PORTAL_LOGIN_FAILED.getDetail());
+                softly.assertThat(response.status()).isEqualTo(AuthException.SEJONG_PORTAL_LOGIN_FAILED.getHttpStatus().value());
+                softly.assertThat(response.instance()).isEqualTo("/api/auth/login/portal");
+            });
+        }
+    }
+
+}

--- a/src/test/java/com/greedy/zupzup/common/ControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/common/ControllerTest.java
@@ -1,5 +1,6 @@
 package com.greedy.zupzup.common;
 
+import com.greedy.zupzup.auth.jwt.JwtTokenProvider;
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.domain.Feature;
 import com.greedy.zupzup.category.domain.FeatureOption;
@@ -71,12 +72,19 @@ public abstract class ControllerTest {
     @Autowired
     protected QuizAttemptRepository quizAttemptRepository;
 
+    @Autowired
+    protected JwtTokenProvider jwtTokenProvider;
+
     @LocalServerPort
     protected int port;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+    }
+
+    protected String givenAccessToken(Member member) {
+        return jwtTokenProvider.createAccessToken(member);
     }
 
     protected Member givenMember(String password) {

--- a/src/test/java/com/greedy/zupzup/common/ControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/common/ControllerTest.java
@@ -8,6 +8,7 @@ import com.greedy.zupzup.category.repository.FeatureOptionRepository;
 import com.greedy.zupzup.category.repository.FeatureRepository;
 import com.greedy.zupzup.common.fixture.CategoryFixture;
 import com.greedy.zupzup.common.fixture.LostItemImageFixture;
+import com.greedy.zupzup.common.fixture.MemberFixture;
 import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
@@ -32,6 +33,7 @@ import java.util.List;
 
 import static com.greedy.zupzup.common.fixture.FeatureFixture.*;
 import static com.greedy.zupzup.common.fixture.FeatureOptionFixture.*;
+import static com.greedy.zupzup.common.fixture.MemberFixture.*;
 import static com.greedy.zupzup.common.fixture.SchoolAreaFixture.*;
 
 @Sql("/truncate.sql")
@@ -75,6 +77,11 @@ public abstract class ControllerTest {
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+    }
+
+    protected Member givenMember(String password) {
+        Member member = MEMBER_WITH_ENCODED_PASSWORD(password);
+        return memberRepository.save(member);
     }
 
     protected List<SchoolArea> givenSchoolAreas() {

--- a/src/test/java/com/greedy/zupzup/common/fixture/MemberFixture.java
+++ b/src/test/java/com/greedy/zupzup/common/fixture/MemberFixture.java
@@ -8,7 +8,7 @@ public class MemberFixture {
     public static Member MEMBER() {
         return Member.builder()
                 .name("테스트유저")
-                .studentId("naver-test-id-12345")
+                .studentId(123456)
                 .role(Role.USER)
                 .build();
     }

--- a/src/test/java/com/greedy/zupzup/common/fixture/MemberFixture.java
+++ b/src/test/java/com/greedy/zupzup/common/fixture/MemberFixture.java
@@ -1,19 +1,15 @@
 package com.greedy.zupzup.common.fixture;
 
 import com.greedy.zupzup.member.domain.Member;
-import com.greedy.zupzup.member.domain.Provider;
 import com.greedy.zupzup.member.domain.Role;
 
 public class MemberFixture {
 
     public static Member MEMBER() {
         return Member.builder()
-                .email("testuser@naver.com")
-                .nickname("테스트유저")
-                .provider(Provider.NAVER)
-                .providerId("naver-test-id-12345")
+                .name("테스트유저")
+                .studentId("naver-test-id-12345")
                 .role(Role.USER)
-                .emailConsent(true)
                 .build();
     }
 }

--- a/src/test/java/com/greedy/zupzup/common/fixture/MemberFixture.java
+++ b/src/test/java/com/greedy/zupzup/common/fixture/MemberFixture.java
@@ -2,6 +2,7 @@ package com.greedy.zupzup.common.fixture;
 
 import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.member.domain.Role;
+import org.mindrot.jbcrypt.BCrypt;
 
 public class MemberFixture {
 
@@ -9,6 +10,19 @@ public class MemberFixture {
         return Member.builder()
                 .name("테스트유저")
                 .studentId(123456)
+                .password("asd")
+                .role(Role.USER)
+                .build();
+    }
+
+    /**
+     * 암호화된 비밀번호가 필요한 DB 저장 및 API 인수 테스트용
+     */
+    public static Member MEMBER_WITH_ENCODED_PASSWORD(String password) {
+        return Member.builder()
+                .name("테스트유저")
+                .studentId(123456)
+                .password(BCrypt.hashpw(password, BCrypt.gensalt()))
                 .role(Role.USER)
                 .build();
     }


### PR DESCRIPTION
## 📎 Issue 번호
- closed: #38 

## ✨ 작업 내용
> 세종대학교 포털 인증과 로그인 기능을 추가했습니다


- member 엔티티(테이블) 수정
- 세종대학교 포탈 학생 인증 구현
- 엑세스 토큰 발급 및 인터셉터를 통한 인증/인가 구현
- 1번 방식. 세종대학교 포털 인증으로만 로그인을 진행  (데모데이용)
- 2번 방식. 세종대학교 포털 인증 + 별도 자체 서비스 가입을 통한 로그인 구현
- 서비스 가입 시 비밀번호 암호화
- 로그아웃 기능 구현

## 🎯 리뷰 포인트


## 📝 기타

### ❗️ 필독 ❗️

### [Argument Resolver]

- 이제 로그인이 필요한 API의 경우에는 `@MemberAuth LoginMember loginMember` 와 같이 어노테이션으로 멤버의 아이디를 담은 `LoginMember`를 받아 올 수 있습니다.
```java
@PostMapping("/test")
    public ResponseEntity<LoginMember> test(@MemberAuth LoginMember loginMember) {
   // 컨트롤러 로직

        return ResponseEntity.ok(loginMember);
    }
```

<br>

### [인증이 필요 없는 API 경로 제어]

- 인증이 필요하지 않은 API의 경우에는 `WebConfig` 파일의 `excludePathPatterns`에 추가해 주어야 합니다.
```java
@Override
    public void addInterceptors(InterceptorRegistry registry) {
        registry.addInterceptor(authInterceptor)
                .addPathPatterns("/api/**")
                .excludePathPatterns(
                        "/api/auth/**",
                        "/api/lost-items/summary",
                        "/api/lost-items",
                        "/api/lost-items/*",
                        "/api/school-areas/**",
                        "/api/categories/**"
                );
    }
```
인터셉터의 한계로, 메서드는 다르지만, 같은 경로의 메서드 별로 세부적인 처리는 어렵기 때문에 이 부분은 인터셉터 단에서 화이트 리스트로 요청을 필터링 및 관리를 하는 등의 처리가 필요할 것 같습니다.
(아직은 설계한 API 가 같은 경로인데, 하나는 인증이 필요한 경우가 없네용)

<br>

### [두 가지 로그인 방식]

- 일단은 `포털 인증으로 바로 로그인`을 하는 API도 만들어 두었는데, 
- 저희 데모데이 용으로만 쓰고 서비스를 출시하고는 삭제 해야 할 것 같습니당 (API가 빨라도 1~2 초가 걸리고, 늦으면 6초까지 걸리더라구요 ㅎㅎ..) 
- 때문에 세종대학교 인증 + 자체 서비스 가입 하는 API 도 미리 만들어 두었어용

<br>

### [인증 인가 전략]
- 기본적인 인증 인가는 단일 토큰 전략(억세스 토큰 만)으로 구성했습니다. 
- 우리 서비스가 로그인이 필요한 기능이 별로 없기도 하고, 크게 민감 정보를 가진 서비스가 아니기 때문에 현재로써는 단일 토큰 전략을 도입을 하는게 타탕해 보여요. (이에 대해서 어떻게 생각 하는지 각자 생각들이 궁금하네용)
- 그리고 UX를 고려해서, 리프레시를 도입하기에는 짧은 개발 기간 때문에 프론트가 부담을 많이 느낄 것 같아 나중에 고도화를 해도 될 것 같아용

억세스 토큰 유효기간 3시간정도를 생각하고 있기는 한데 어떻게 생각 하시는지? 좀 더 늘려도 좋을 지? **의견 꼭 남겨 주세요!**

<br>

### [세종대학교 인증]
- 현재 세종대학교 인증을 하는 API 를 만들어 놓았는데, 인증이 완료가 되면 세션을 유지해서  서버 톰캣 메모리의 세션 스토리지에 학번 이름을 저장하고, 
- 줍줍 서비스 가입 시 인증된 사용자만 가입이 가능 하도록 구성했어요

세션 유지 기간은 10분 정도로 생각 중인데 너무 짧으려나요?? ㅋㅋㅌ (의견 주세요)

<br>


### [로그인 머지가 되면..]
- 로그인 기능이 머지가 되면, 분실물 찾기나 분실물 상세 조회 조회 같은 API 는 `@MemberAuth LoginMember loginMember`  로 멤버 정보를 받도록 수정해 주시면 될 것 같아요
- 또한 지금은 아래와 같이 인터셉터가 인증이 필요한  API 에 대해 접근을 제한하고 있기 때문에 각자 맡은 API의 테스트 코드를 수정해주세요!

<img width="424" height="407" alt="image" src="https://github.com/user-attachments/assets/900b1681-2de9-481c-81d9-c17a3868ff4d" />

<br>


- 테스트시 DB에 저장할 더미 멤버는 컨트롤러 테스트 추상 클래스의 다음 메서드를 이용해 주면 됩니다!
- DB 저장 시 비밀번호를 암호화 했어서 픽스처에서도 암호화 되도록 작성해 두었어요~~ 
  (직접 테스트를 작성해 보면서 아래 코드가 제가 생각한 대로 흘러갈지 확인을 못해봤는데, 혹시 문제가 있다면 말씀해 주세여)

```java
protected Member givenMember(String password) {
        Member member = MEMBER_WITH_ENCODED_PASSWORD(password);
        return memberRepository.save(member);
    }
```


<br>

뭔가 설명이 너무 길었네요 😅 
아무래도 로그인과 인증/인가 가 프로그램 전반에 영향이 있는지라 최대한 각자 생각의 싱크를 맞추는 것이 중요하다고 생각해요

이해가 안되는 점이나 왜 이렇게 작성한건지 의도를 모르겠는거나, 개선할 점이 있다면 말해 주세용~~

다음주 배포까지 화이팅 🔥🔥🔥🔥🔥🔥


## ✅ 테스트
- [x] 수동 테스트 완료
- [x] 테스트 코드 완료
