### PR TITLE
docs: 학교 구역 조회, 분실물 등록 API에 대한 swagger 작성

### DIFF
--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -80,7 +81,7 @@ public class AuthController implements AuthControllerDocs {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletResponse response) {
         CookieUtil.setToken("", 0, response);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
 

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthControllerDocs.java
@@ -26,69 +26,99 @@ public interface AuthControllerDocs {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "세종대학교 포털 인증에 성공하고, 서버 세션에 인증 정보가 저장된 경우",
-                    content = @Content(schema = @Schema(implementation = VerifiedStudentResponse.class),
-                            examples = @ExampleObject(name = "세종대학교 인증 성공 예시", value = """
-                                    {
-                                        "studentId": 20011222,
-                                        "message": "세종대학교 인증에 성공했습니다."
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = VerifiedStudentResponse.class),
+                            examples = @ExampleObject(
+                                    name = "세종대학교 인증 성공 예시",
+                                    value = """
+                                            {
+                                                "studentId": 20011222,
+                                                "message": "세종대학교 인증에 성공했습니다."
+                                            }
+                                            """
                             )
                     )
             ),
 
-            @ApiResponse(responseCode = "400", description = "요청 본문의 portalId 또는 portalPassword가 누락되었거나 형식이 올바르지 않은 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "잘못된 요청 본문 (body) 예시", value = """
-                                    {
-                                        "title": "잘못된 요청 본문",
-                                        "status": 400,
-                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
-                                        "instance": "/api/auth/verify-sejong"
-                                    }
-                                    """
-                            )
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+
+                                    @ExampleObject(
+                                            name = "필수 요청 필드가 누락된 경우",
+                                            value = """
+                                                    {
+                                                        "title": "유효하지 않은 입력값",
+                                                        "status": 400,
+                                                        "detail": "portalPassword: 세종대학교 포털 로그인 비밀번호를 입력해 주세요., portalId: 세종대학교 포털 로그인 학번을 입력해 주세요.",
+                                                        "instance": "/api/auth/verify-sejong"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "Body에 포함된 JSON 데이터를 파싱에 실패 하거나 JSON 형식이 잘못된 경우",
+                                            value = """
+                                                    {
+                                                        "title": "잘못된 요청 본문",
+                                                        "status": 400,
+                                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
+                                                        "instance": "/api/auth/verify-sejong"
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
 
             @ApiResponse(responseCode = "401", description = "제출된 portalId와 portalPassword가 실제 포털 정보와 일치하지 않아 인증에 실패한 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "포털 로그인 실패 예시", value = """
-                                    {
-                                        "title": "세종대학교 포털 로그인 실패",
-                                        "status": 401,
-                                        "detail": "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요.",
-                                        "instance": "/api/auth/verify-sejong"
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "세종대학교 포털 인증에 실패한 경우",
+                                    value = """
+                                            {
+                                                "title": "세종대학교 포털 로그인 실패",
+                                                "status": 401,
+                                                "detail": "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요.",
+                                                "instance": "/api/auth/verify-sejong"
+                                            }
+                                            """
                             )
                     )
             ),
 
             @ApiResponse(responseCode = "409", description = "인증에 성공했으나, 해당 학번으로 이미 서비스에 가입된 회원이 존재하는 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "이미 가입된 사용자 예시", value = """
-                                    {
-                                        "title": "가입된 사용자",
-                                        "status": 409,
-                                        "detail": "이미 가입된 사용자 입니다.",
-                                        "instance": "/api/auth/verify-sejong"
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "이미 가입된 사용자 예시",
+                                    value = """
+                                            {
+                                                "title": "가입된 사용자",
+                                                "status": 409,
+                                                "detail": "이미 가입된 사용자 입니다.",
+                                                "instance": "/api/auth/verify-sejong"
+                                            }
+                                            """
                             )
                     )
             ),
 
             @ApiResponse(responseCode = "503", description = "세종대학교 포털 서버 자체의 문제나 네트워크 오류로 인해 인증 시도가 불가능한 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "포털 인증 실패 예시", value = """
-                                    {
-                                        "title": "세종대학교 포털 서버 통신 오류",
-                                        "status": 503,
-                                        "detail": "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
-                                        "instance": "/api/auth/verify-sejong"
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "포털 인증 실패 예시",
+                                    value = """
+                                            {
+                                                "title": "세종대학교 포털 서버 통신 오류",
+                                                "status": 503,
+                                                "detail": "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+                                                "instance": "/api/auth/verify-sejong"
+                                            }
+                                            """
                             )
                     )
             )
@@ -103,11 +133,11 @@ public interface AuthControllerDocs {
                                     @ExampleObject(
                                             name = "정상 요청 예시",
                                             value = """
-                                                {
-                                                    "portalId": "2001111 (본인 포탈 로그인 아이디)",
-                                                    "portalPassword": "asdasdasd (본인 포탈 로그인 PW)"
-                                                }
-                                                """
+                                                    {
+                                                        "portalId": "2001111 (본인 포탈 로그인 아이디)",
+                                                        "portalPassword": "asdasdasd (본인 포탈 로그인 PW)"
+                                                    }
+                                                    """
                                     )
                             }
                     )
@@ -123,34 +153,78 @@ public interface AuthControllerDocs {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "회원가입에 성공하고, 새로운 회원 리소스가 성공적으로 생성된 경우",
-                    content = @Content(schema = @Schema(implementation = SignupResponse.class),
-                            examples = @ExampleObject(name = "회원가입 성공 예시", value = """
-                                    {
-                                        "memberId": 2,
-                                        "message": "회원가입에 성공했습니다!"
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = SignupResponse.class),
+                            examples = @ExampleObject(
+                                    name = "회원가입 성공 예시",
+                                    value = """
+                                            {
+                                                "memberId": 2,
+                                                "message": "회원가입에 성공했습니다!"
+                                            }
+                                            """
                             )
                     )
             ),
 
-            @ApiResponse(responseCode = "400", description = "요청 본문의 password 등이 서버에서 정의한 유효성 규칙(예: 길이, 형식)을 통과하지 못한 경우 + 요청 본문의 형식이 잘못된 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "잘못된 요청 (비밀번호 입력) 예시", value = """
-                                    {
-                                        "title": "유효하지 않은 입력값",
-                                        "status": 400,
-                                        "detail": "password: 비밀번호는 6~20자 길이의 영문, 숫자, 특수문자만 사용할 수 있습니다.",
-                                        "instance": "/api/auth/signup"
-                                    }
-                                    """
-                            )
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "가입 요청된 password가 서버에서 정의한 유효성 규칙(예: 길이, 형식)을 통과하지 못한 경우",
+                                            value = """
+                                                    {
+                                                        "title": "유효하지 않은 입력값",
+                                                        "status": 400,
+                                                        "detail": "password: 비밀번호는 6~20자 길이의 영문, 숫자, 특수문자만 사용할 수 있습니다.",
+                                                        "instance": "/api/auth/signup"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "필수 입력 필드가 누락된 경우 ",
+                                            value = """
+                                                    {
+                                                        "title": "유효하지 않은 입력값",
+                                                        "status": 400,
+                                                        "detail": "password: 비밀번호는 필수입니다.",
+                                                        "instance": "/api/auth/signup"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "가입 요청된 학번과 세종대학교 포털 인증한 학변이 다른 경우",
+                                            value = """
+                                                    {
+                                                        "title": "인증 정보 불일치",
+                                                        "status": 400,
+                                                        "detail": "가입 요청된 학번과, 인증된 학번이 일치하지 않습니다.",
+                                                        "instance": "/api/auth/signup"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "Body에 포함된 JSON 데이터를 파싱에 실패 하거나 JSON 형식이 잘못된 경우",
+                                            value = """
+                                                    {
+                                                        "title": "잘못된 요청 본문",
+                                                        "status": 400,
+                                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
+                                                        "instance": "/api/auth/verify-sejong"
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
 
-            @ApiResponse(responseCode = "401", description = "요청에 포함된 세션(JSESSIONID)이 없거나 만료되어, 세종대 학생 인증 상태를 확인할 수 없는 경우",
+            @ApiResponse(responseCode = "401", description = "요청에 포함된 세션(JSESSIONID)이 없거나 만료되어, 세종대학교 인증 상태를 확인할 수 없는 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "세종대학교 인증 정보 없음 또는 만료 예시", value = """
+                            examples = @ExampleObject(name = "세종대학교 인증 정보 없음 또는 만료", value = """
                                     {
                                         "title": "세종대학교 인증 필요",
                                         "status": 401,
@@ -161,7 +235,6 @@ public interface AuthControllerDocs {
                             )
                     )
             ),
-
     })
     ResponseEntity<SignupResponse> signup(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -173,11 +246,11 @@ public interface AuthControllerDocs {
                                     @ExampleObject(
                                             name = "정상 요청 예시",
                                             value = """
-                                                {
-                                                    "studentId": 20011111,
-                                                    "password": "asdasda@123"
-                                                }
-                                                """
+                                                    {
+                                                        "studentId": 20011111,
+                                                        "password": "asdasda@123"
+                                                    }
+                                                    """
                                     )
                             }
                     )
@@ -187,47 +260,70 @@ public interface AuthControllerDocs {
     );
 
 
-
     @Operation(summary = "줍줍 로그인",
             description = "줍줍 아이디와 비밀번호를 사용하여 로그인합니다. 성공 시, Access Token이 쿠키에 설정됩니다."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인에 성공하고, access_token이 쿠키에 정상적으로 설정된 경우",
-                    content = @Content(schema = @Schema(implementation = LoginResponse.class),
-                            examples = @ExampleObject(name = "줍줍 로그인 성공 예시", value = """
-                                    {
-                                        "memberId": 2,
-                                        "message": "로그인에 성공했습니다."
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = LoginResponse.class),
+                            examples = @ExampleObject(
+                                    name = "줍줍 로그인 성공 예시",
+                                    value = """
+                                            {
+                                                "memberId": 2,
+                                                "message": "로그인에 성공했습니다."
+                                            }
+                                            """
                             )
                     )
             ),
 
-            @ApiResponse(responseCode = "400", description = "요청 본문의 studentId 또는 password가 누락된 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "잘못된 요청 본문 (body) 예시", value = """
-                                    {
-                                        "title": "잘못된 요청 본문",
-                                        "status": 400,
-                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
-                                        "instance": "/api/auth/login"
-                                    }
-                                    """
-                            )
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+
+                                    @ExampleObject(
+                                            name = "필수 입력 필드가 누락된 경우",
+                                            value = """
+                                                    {
+                                                        "title": "유효하지 않은 입력값",
+                                                        "status": 400,
+                                                        "detail": "studentId: 줍줍 로그인 학번을 입력해 주세요.",
+                                                        "instance": "/api/auth/login"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "Body에 포함된 JSON 데이터를 파싱에 실패 하거나 JSON 형식이 잘못된 경우",
+                                            value = """
+                                                    {
+                                                        "title": "잘못된 요청 본문",
+                                                        "status": 400,
+                                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
+                                                        "instance": "/api/auth/login"
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
 
             @ApiResponse(responseCode = "401", description = "존재하지 않는 studentId로 로그인을 시도했거나, password가 일치하지 않는 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "줍줍 로그인 실패 예시", value = """
-                                    {
-                                        "title": "로그인 실패",
-                                        "status": 401,
-                                        "detail": "아이디 또는 패스워드가 일치하지 않습니다.",
-                                        "instance": "/api/auth/login"
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "줍줍 로그인 실패 예시",
+                                    value = """
+                                            {
+                                                "title": "로그인 실패",
+                                                "status": 401,
+                                                "detail": "아이디 또는 패스워드가 일치하지 않습니다.",
+                                                "instance": "/api/auth/login"
+                                            }
+                                            """
                             )
                     )
             )
@@ -242,11 +338,11 @@ public interface AuthControllerDocs {
                                     @ExampleObject(
                                             name = "정상 요청 예시",
                                             value = """
-                                                {
-                                                    "studentId": 20011111,
-                                                    "password": "asdasda@123"
-                                                }
-                                                """
+                                                    {
+                                                        "studentId": 20011111,
+                                                        "password": "asdasda@123"
+                                                    }
+                                                    """
                                     )
                             }
                     )
@@ -255,83 +351,93 @@ public interface AuthControllerDocs {
     );
 
 
-
-
     @Operation(summary = "로그아웃",
             description = "사용자를 로그아웃 처리하고, 저장된 억세스 토큰(쿠키)을 삭제합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청에 포함된 access_token 쿠키가 성공적으로 만료(삭제) 처리된 경우")
+            @ApiResponse(responseCode = "204", description = "요청에 포함된 access_token 쿠키가 성공적으로 만료(삭제) 처리된 경우")
     })
     ResponseEntity<Void> logout(@Parameter(hidden = true) HttpServletResponse response);
-
-
 
 
     @Operation(summary = "포털 로그인 (데모용)",
             description = "세종대학교 포털 인증과 로그인을 동시에 처리합니다. 기존 회원은 로그인 처리되며, 신규 회원은 자동 가입 후 로그인됩니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "포털 인증에 성공하고, 줍줍 서비스 access_token이 쿠키에 설정된 경우",
-                    content = @Content(schema = @Schema(implementation = LoginResponse.class),
-                            examples = @ExampleObject(name = "포털 로그인으로 즉시 줍줍 로그인 성공 예시", value = """
-                                    {
-                                        "memberId": 2,
-                                        "message": "로그인에 성공했습니다."
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = LoginResponse.class),
+                            examples = @ExampleObject(
+                                    name = "포털 로그인으로 즉시 줍줍 로그인 성공 예시",
+                                    value = """
+                                            {
+                                                "memberId": 2,
+                                                "message": "로그인에 성공했습니다."
+                                            }
+                                            """
                             )
                     )
             ),
-            @ApiResponse(responseCode = "400", description = "요청 본문의 portalId 또는 portalPassword가 누락되었거나 형식이 올바르지 않은 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "잘못된 요청 본문 (body) 예시", value = """
-                                    {
-                                        "title": "잘못된 요청 본문",
-                                        "status": 400,
-                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
-                                        "instance": "/api/auth/login/portal"
-                                    }
-                                    """
-                            )
-                    )
-            ),
-            @ApiResponse(responseCode = "401", description = "제출된 portalId와 portalPassword가 실제 포털 정보와 일치하지 않아 인증에 실패한 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "포털 로그인 실패 예시", value = """
-                                    {
-                                        "title": "세종대학교 포털 로그인 실패",
-                                        "status": 401,
-                                        "detail": "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요.",
-                                        "instance": "/api/auth/login/portal"
-                                    }
-                                    """
-                            )
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+
+                                    @ExampleObject(
+                                            name = "필수 요청 필드가 누락된 경우",
+                                            value = """
+                                                    {
+                                                        "title": "유효하지 않은 입력값",
+                                                        "status": 400,
+                                                        "detail": "portalPassword: 세종대학교 포털 로그인 비밀번호를 입력해 주세요., portalId: 세종대학교 포털 로그인 학번을 입력해 주세요.",
+                                                        "instance": "/api/auth/verify-sejong"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "Body에 포함된 JSON 데이터를 파싱에 실패 하거나 JSON 형식이 잘못된 경우",
+                                            value = """
+                                                    {
+                                                        "title": "잘못된 요청 본문",
+                                                        "status": 400,
+                                                        "detail": "요청 본문의 형식이 잘못되었습니다.",
+                                                        "instance": "/api/auth/login/portal"
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
 
-            @ApiResponse(responseCode = "409", description = "인증에 성공했으나, 해당 학번으로 이미 서비스에 가입된 회원이 존재하는 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "이미 가입된 사용자 예시", value = """
-                                    {
-                                        "title": "가입된 사용자",
-                                        "status": 409,
-                                        "detail": "이미 가입된 사용자 입니다.",
-                                        "instance": "/api/login/portal"
-                                    }
-                                    """
+            @ApiResponse(responseCode = "401", description = "제출된 portalId와 portalPassword가 실제 포털 정보와 일치하지 않아 인증에 실패한 경우",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "포털 로그인 실패 예시",
+                                    value = """
+                                            {
+                                                "title": "세종대학교 포털 로그인 실패",
+                                                "status": 401,
+                                                "detail": "세종대학교 인증에 실패했습니다. 아이디 비밀번호를 다시 한번 확인해 주세요.",
+                                                "instance": "/api/auth/login/portal"
+                                            }
+                                            """
                             )
                     )
             ),
 
             @ApiResponse(responseCode = "503", description = "세종대학교 포털 서버 자체의 문제나 네트워크 오류로 인해 인증 시도가 불가능한 경우",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "포털 인증 실패 예시", value = """
-                                    {
-                                        "title": "세종대학교 포털 서버 통신 오류",
-                                        "status": 503,
-                                        "detail": "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
-                                        "instance": "/api/auth/login/portal"
-                                    }
-                                    """
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "포털 인증 실패 예시",
+                                    value = """
+                                            {
+                                                "title": "세종대학교 포털 서버 통신 오류",
+                                                "status": 503,
+                                                "detail": "세종대학교 포털 서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+                                                "instance": "/api/auth/login/portal"
+                                            }
+                                            """
                             )
                     )
             )
@@ -346,11 +452,11 @@ public interface AuthControllerDocs {
                                     @ExampleObject(
                                             name = "정상 요청 예시",
                                             value = """
-                                                {
-                                                    "portalId": "2001111 (본인 포탈 로그인 아이디)",
-                                                    "portalPassword": "asdasdasd (본인 포탈 로그인 PW)"
-                                                }
-                                                """
+                                                    {
+                                                        "portalId": "2001111 (본인 포탈 로그인 아이디)",
+                                                        "portalPassword": "asdasdasd (본인 포탈 로그인 PW)"
+                                                    }
+                                                    """
                                     )
                             }
                     )

--- a/src/main/java/com/greedy/zupzup/category/exception/CategoryException.java
+++ b/src/main/java/com/greedy/zupzup/category/exception/CategoryException.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum CategoryException implements ExceptionCode {
 
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없음", "요청하신 카테고리를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없음", "요청하신 카테고리가 존재하지 않습니다."),
     INVALID_CATEGORY_FEATURE(HttpStatus.BAD_REQUEST, "잘못된 특징값", "요청하신 카테고리의 특징값이 해당 카테고리의 특징이 아닙니다.")
     ;
 

--- a/src/main/java/com/greedy/zupzup/global/config/SwaggerConfig.java
+++ b/src/main/java/com/greedy/zupzup/global/config/SwaggerConfig.java
@@ -38,10 +38,6 @@ public class SwaggerConfig {
                 .in(SecurityScheme.In.COOKIE)
                 .description("서비스 로그인 성공 후 발급되는 Access Token 쿠키");
 
-        SecurityRequirement securityRequirement = new SecurityRequirement()
-                .addList(sejongSessionAuth)
-                .addList(zupzupAccessTokenAuth);
-
         List<Server> servers = List.of(
                 new Server().url("http://localhost:8080").description("로컬 서버"),
                 new Server().url("https://api.sejong-zupzup.kr").description("메인 서버")
@@ -51,7 +47,6 @@ public class SwaggerConfig {
                 .servers(servers)
                 .components(new Components()
                         .addSecuritySchemes(sejongSessionAuth, sejongSessionScheme)
-                        .addSecuritySchemes(zupzupAccessTokenAuth, accessTokenScheme))
-                .addSecurityItem(securityRequirement);
+                        .addSecuritySchemes(zupzupAccessTokenAuth, accessTokenScheme));
     }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemController.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemController.java
@@ -1,13 +1,12 @@
 package com.greedy.zupzup.lostitem.presentation;
 
-import com.greedy.zupzup.auth.presentation.annotation.MemberAuth;
-import com.greedy.zupzup.auth.presentation.argumentresolver.LoginMember;
 import com.greedy.zupzup.lostitem.application.LostItemRegisterService;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.presentation.dto.LostItemRegisterRequest;
 import com.greedy.zupzup.lostitem.presentation.dto.LostItemRegisterResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,11 +17,11 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/lost-items")
-public class LostItemController {
+public class LostItemController implements LostItemControllerDocs {
 
     private final LostItemRegisterService lostItemRegisterService;
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<LostItemRegisterResponse> create(@RequestPart("images") List<MultipartFile> images,
                                                            @Valid @RequestPart("lostItemRegisterRequest") LostItemRegisterRequest lostItemRegisterRequest) {
         LostItem lostItem = lostItemRegisterService.registLostItem(lostItemRegisterRequest.toCommand(images));

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/LostItemControllerDocs.java
@@ -1,0 +1,202 @@
+package com.greedy.zupzup.lostitem.presentation;
+
+import com.greedy.zupzup.global.exception.ErrorResponse;
+import com.greedy.zupzup.lostitem.presentation.dto.LostItemMultipartDocs;
+import com.greedy.zupzup.lostitem.presentation.dto.LostItemRegisterRequest;
+import com.greedy.zupzup.lostitem.presentation.dto.LostItemRegisterResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "Lost Item Register", description = "분실물 등록 API")
+public interface LostItemControllerDocs {
+
+    @Operation(
+            summary = "분실물 등록",
+            description = "이미지를(최대 3장)과 분실물 정보(JSON)를 함께 업로드합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "분실물 등록에 성공힌 경우",
+                    content = @Content(
+                            schema = @Schema(implementation = LostItemRegisterResponse.class),
+                            examples = @ExampleObject(
+                                    name = "분실물 등록 성공 예시",
+                                    value = """
+                                            {
+                                              "lostItemId": 1,
+                                              "message": "분실물 등록에 성공했습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "필수 입력값(보관 장소, 상세 습득장소)을 누락하여 요청한 경우",
+                                            value = """
+                                                    {
+                                                      "title": "유효하지 않은 입력값",
+                                                      "status": 400,
+                                                      "detail": "depositArea: 분실물의 보관 장소를 자세히 입력해 주세요, foundAreaDetail: 분실물의 습득 장소의 자세한 정보를 입력해 주세요.",
+                                                      "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "카테고리와 일치하지 않는 특징으로 등록 요청을 보낸 경우",
+                                            value = """
+                                                    {
+                                                        "title": "잘못된 특징값",
+                                                        "status": 400,
+                                                        "detail": "요청하신 카테고리의 특징값이 해당 카테고리의 특징이 아닙니다.",
+                                                        "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "카테고리와 특징값은 일치하지만 일치하지 않는 옵션으로 등록 요청을 보낸 경우",
+                                            value = """
+                                                    {
+                                                        "title": "잘못된 옵션값",
+                                                        "status": 400,
+                                                        "detail": "요청하신 특징에 대한 옵션값이 해당 특징에 대한 옵션이 아닙니다.",
+                                                        "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "이미지 파일 크기 초과",
+                                            value = """
+                                                    {
+                                                       "title": "지원하지 않는 파일",
+                                                       "status": 400,
+                                                       "detail": "파일 크기는 10MB를 초과할 수 없습니다.",
+                                                       "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "이미지 파일이 아닌 파일을 입력한 경우",
+                                            value = """
+                                                    {
+                                                       "title": "지원하지 않는 파일",
+                                                       "status": 400,
+                                                       "detail": "이미지 파일만 업로드가 가능합니다.",
+                                                       "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "사진이 입력되지 않은 경우",
+                                            value = """
+                                                    {
+                                                       "title": "이미지가 입력되지 않음",
+                                                       "status": 400,
+                                                       "detail": "업로드할 이미지 파일을 선택해주세요.",
+                                                       "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "사진을 세장 이상 전송한 경우",
+                                            value = """
+                                                    {
+                                                       "title": "잘못된 이미지 개수입니다.",
+                                                       "status": 400,
+                                                       "detail": "분실물 사진은 최소 1개 이상 3개 이하로 등록해야 합니다.",
+                                                       "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 카테고리 or 학교 구역으로 등록을 요청한 경우",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 카테고리 id로 요청",
+                                            value = """
+                                                    {
+                                                      "title": "카테고리를 찾을 수 없음",
+                                                      "status": 404,
+                                                      "detail": "요청하신 카테고리가 존재하지 않습니다.",
+                                                      "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 학교 구역 id로 요청",
+                                            value = """
+                                                    {
+                                                      "title": "학교 구역을 찾을 수 없음",
+                                                      "status": 404,
+                                                      "detail": "요청하신 학교 구역이 존재하지 않습니다.",
+                                                      "instance": "/api/lost-items"
+                                                    }
+                                                    """
+                                    ),
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "이미지 저장에 실패한 경우",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "이미지 업로드가 실패한 경우",
+                                    value = """
+                                            {
+                                                "title": "이미지 업로드 실패",
+                                                "status": 500,
+                                                "detail": "이미지 업로드에 실패했습니다.",
+                                                "instance": "/api/lost-items"
+                                            }
+                                            """
+
+                            )
+                    )
+            )
+
+    })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @RequestBody(
+            required = true,
+            content = @Content(
+                    mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    schema = @Schema(implementation = LostItemMultipartDocs.class),
+                    encoding = {
+                            @Encoding(name = "images", contentType = "image/*"),
+                            @Encoding(name = "lostItemRegisterRequest", contentType = "application/json")
+                    }
+            )
+    )
+    ResponseEntity<LostItemRegisterResponse> create(
+            @RequestPart("images") List<MultipartFile> images,
+            @Valid @RequestPart("lostItemRegisterRequest") LostItemRegisterRequest lostItemRegisterRequest
+    );
+}

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/dto/LostItemMultipartDocs.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/dto/LostItemMultipartDocs.java
@@ -1,0 +1,23 @@
+package com.greedy.zupzup.lostitem.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Schema(name = "LostItemMultipartDoc", description = "분실물 등록 멀티파트 폼")
+public record LostItemMultipartDocs(
+        @ArraySchema(
+                arraySchema = @Schema(description = "분실물 이미지 파일 리스트"),
+                schema = @Schema(type = "string", format = "binary")
+        )
+        List<MultipartFile> images,
+
+        @Schema(
+                description = "분실물 등록 요청 JSON",
+                implementation = LostItemRegisterRequest.class
+        )
+        LostItemRegisterRequest lostItemRegisterRequest
+) {
+}

--- a/src/main/java/com/greedy/zupzup/schoolarea/exception/SchoolAreaException.java
+++ b/src/main/java/com/greedy/zupzup/schoolarea/exception/SchoolAreaException.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SchoolAreaException implements ExceptionCode {
 
-    SCHOOL_AREA_OUT_OF_BOUND(HttpStatus.NOT_FOUND, "유효하지 않은 구역", "해당 좌표는 세종대학교를 벗어났습니다."),
-    SCHOOL_AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 구역을 찾을 수 없음", "해당 id의 구역은 존재하지 않습니다.")
+    SCHOOL_AREA_OUT_OF_BOUND(HttpStatus.NOT_FOUND, "유효하지 않은 구역", "요청하신 좌표는 세종대학교를 벗어났습니다."),
+    SCHOOL_AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "학교 구역을 찾을 수 없음", "요청하신 구역이 존재하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greedy/zupzup/schoolarea/exception/SchoolAreaException.java
+++ b/src/main/java/com/greedy/zupzup/schoolarea/exception/SchoolAreaException.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SchoolAreaException implements ExceptionCode {
 
-    SCHOOL_AREA_OUT_OF_BOUND(HttpStatus.BAD_REQUEST, "유효하지 않은 구역", "해당 좌표는 학교 범위를 벗어났습니다."),
+    SCHOOL_AREA_OUT_OF_BOUND(HttpStatus.NOT_FOUND, "유효하지 않은 구역", "해당 좌표는 세종대학교를 벗어났습니다."),
     SCHOOL_AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 구역을 찾을 수 없음", "해당 id의 구역은 존재하지 않습니다.")
     ;
 

--- a/src/main/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaController.java
+++ b/src/main/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaController.java
@@ -7,9 +7,11 @@ import com.greedy.zupzup.schoolarea.presentation.dto.LatLngRequest;
 import com.greedy.zupzup.schoolarea.presentation.dto.SchoolAreaResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -17,12 +19,12 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/school-areas")
-public class SchoolAreaController {
+public class SchoolAreaController implements SchoolAreaControllerDocs {
 
     private final SchoolAreaService schoolAreaService;
 
     @GetMapping("/contains")
-    public ResponseEntity<SchoolAreaResponse> findArea(@Valid LatLngRequest request) {
+    public ResponseEntity<SchoolAreaResponse> findArea(@ParameterObject @Valid LatLngRequest request) {
         SchoolArea findArea = schoolAreaService.findByLatLng(request.toCommand());
         return ResponseEntity.ok(SchoolAreaResponse.from(findArea));
     }

--- a/src/main/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerDocs.java
@@ -99,7 +99,7 @@ public interface SchoolAreaControllerDocs {
                                             {
                                                  "title": "유효하지 않은 구역",
                                                  "status": 404,
-                                                 "detail": "해당 좌표는 세종대학교를 벗어났습니다.",
+                                                 "detail": "요청하신 좌표는 세종대학교를 벗어났습니다.",
                                                  "instance": "/api/school-areas/contains"
                                             }
                                             """

--- a/src/main/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerDocs.java
@@ -1,0 +1,175 @@
+package com.greedy.zupzup.schoolarea.presentation;
+
+import com.greedy.zupzup.global.exception.ErrorResponse;
+import com.greedy.zupzup.schoolarea.presentation.dto.AllSchoolAreasResponse;
+import com.greedy.zupzup.schoolarea.presentation.dto.LatLngRequest;
+import com.greedy.zupzup.schoolarea.presentation.dto.SchoolAreaResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+
+
+@Tag(name = "SchoolArea", description = "학교 구역 조회 관련 API")
+public interface SchoolAreaControllerDocs {
+
+
+    @Operation(summary = "좌표(위도,경도)로 세종대학교 구역 조회",
+            description = "입력한 위도(lat)와 경도(lng)를 포함하는 학교 구역 정보를 응답합니다."
+    )
+    @Parameters({
+            @Parameter(name = "lat", description = "위도", example = "37.5488", required = true),
+            @Parameter(name = "lng", description = "경도", example = "127.0737", required = true)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청한 좌표를 포함하는 학교 구역 정보 조회에 성공한 경우",
+                    content = @Content(
+                            schema = @Schema(implementation = SchoolAreaResponse.class),
+                            examples = @ExampleObject(
+                                    name = "좌표를 포함하는 학교 구역 정보 조회 성공 예시",
+                                    value = """
+                                            {
+                                              "id": 1,
+                                              "areaName": "집현관",
+                                              "areaPolygon": {
+                                                "coordinates": [
+                                                  {
+                                                    "lat": 37.549313,
+                                                    "lng": 127.0741179
+                                                  },
+                                                  {
+                                                    "lat": 37.5493215,
+                                                    "lng": 127.0733401
+                                                  },
+                                                  {
+                                                    "lat": 37.5484602,
+                                                    "lng": 127.0732891
+                                                  },
+                                                  {
+                                                    "lat": 37.548439,
+                                                    "lng": 127.0740777
+                                                  },
+                                                  {
+                                                    "lat": 37.549313,
+                                                    "lng": 127.0741179
+                                                  }
+                                                ]
+                                              },
+                                              "marker": {
+                                                "lat": 37.5488866,
+                                                "lng": 127.0737063179485
+                                              }
+                                            }
+                                            """
+
+
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 파라미터가 유효하지 않은 경우 (누락 or 위도 경도 범위에서 벗어난 경우 등)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "요청 파라미터로 주어진 위도 경도 값이 잘못된 범위일 경우 예시",
+                                    value = """
+                                            {
+                                                "title": "유효하지 않은 입력값",
+                                                "status": 400,
+                                                "detail": "lng: 경도는 180 이하여야 합니다.",
+                                                "instance": "/api/school-areas/contains"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "주어진 좌표에 해당하는 구역이 존재하지 않는 경우",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "주어진 좌표의 구역이 존재하지 않는 경우 예시",
+                                    value = """
+                                            {
+                                                 "title": "유효하지 않은 구역",
+                                                 "status": 404,
+                                                 "detail": "해당 좌표는 세종대학교를 벗어났습니다.",
+                                                 "instance": "/api/school-areas/contains"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+
+    })
+    ResponseEntity<SchoolAreaResponse> findArea(@ParameterObject @Valid LatLngRequest request);
+
+
+    @Operation(summary = "세종대학교 구역 전체 조회",
+            description = "세종대학교의 전체 구역 정보를 응답합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "세종대학교 전체 구역 정보 조회에 성공한 경우",
+                    content = @Content(
+                            schema = @Schema(implementation = AllSchoolAreasResponse.class),
+                            examples = @ExampleObject(
+                                    name = "세종대학교 전체 구역 정보 조회 성공 예시",
+                                    value = """
+                                            {
+                                              "schoolAreas": [
+                                                {
+                                                  "id": 1,
+                                                  "areaName": "집현관",
+                                                  "areaPolygon": {
+                                                    "coordinates": [
+                                                      {
+                                                        "lat": 37.549313,
+                                                        "lng": 127.0741179
+                                                      },
+                                                      {
+                                                        "lat": 37.5493215,
+                                                        "lng": 127.0733401
+                                                      }
+                                                    ]
+                                                  },
+                                                  "marker": {
+                                                    "lat": 37.5488866,
+                                                    "lng": 127.0737063179485
+                                                  }
+                                                },
+                                                {
+                                                  "id": 2,
+                                                  "areaName": "대양홀",
+                                                  "areaPolygon": {
+                                                    "coordinates": [
+                                                      {
+                                                        "lat": 37.551,
+                                                        "lng": 127.074
+                                                      },
+                                                      {
+                                                        "lat": 37.552,
+                                                        "lng": 127.075
+                                                      }
+                                                    ]
+                                                  },
+                                                  "marker": {
+                                                    "lat": 37.5515,
+                                                    "lng": 127.0745
+                                                  }
+                                                }
+                                              ],
+                                              "count": 2
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<AllSchoolAreasResponse> findAll();
+}

--- a/src/main/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerDocs.java
@@ -77,9 +77,10 @@ public interface SchoolAreaControllerDocs {
             @ApiResponse(responseCode = "400", description = "요청 파라미터가 유효하지 않은 경우 (누락 or 위도 경도 범위에서 벗어난 경우 등)",
                     content = @Content(
                             schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(
-                                    name = "요청 파라미터로 주어진 위도 경도 값이 잘못된 범위일 경우 예시",
-                                    value = """
+                            examples = {
+                                    @ExampleObject(
+                                            name = "요청 파라미터로 주어진 위도/경도 값이 잘못된 범위일 경우",
+                                            value = """
                                             {
                                                 "title": "유효하지 않은 입력값",
                                                 "status": 400,
@@ -87,7 +88,20 @@ public interface SchoolAreaControllerDocs {
                                                 "instance": "/api/school-areas/contains"
                                             }
                                             """
-                            )
+                                    ),
+
+                                    @ExampleObject(
+                                            name = "요청 파라미터로 위도/경도 값(필수 입력 필드)을 입력하지 않은 경우",
+                                            value = """
+                                            {
+                                                "title": "유효하지 않은 입력값",
+                                                "status": 400,
+                                                "detail": "lng: 경도를 입력해주세요.",
+                                                "instance": "/api/school-areas/contains"
+                                            }
+                                            """
+                                    )
+                            }
                     )
             ),
             @ApiResponse(responseCode = "404", description = "주어진 좌표에 해당하는 구역이 존재하지 않는 경우",


### PR DESCRIPTION
## 📎 Issue 번호
- close: #59 

## ✨ 작업 내용
- 학교 구역 조회, 분실물 등록 API에 대한 swagger 작성
- 로그아웃 시 200 OK -> 204 No Content 로 수정
- 좌표로 학교 구역 조회 실패시 400 -> 404 로 수정
- 몇몇 오류 응답 detail 수정 (ex. 카테고리를 찾을 수 없습니다 -> 카테고리가 존재하지 않습니다.)
- Auth API swagger  수정 

## 🎯 리뷰 포인트
- 오류시 응답을 최대한 자세하게 스웨거에서 확인 할 수 있도록 작성했어요 
  (뭔가 빠뜨린게 있거나 추가 될 만한게 있다면 코멘트 남겨 주세요)

## 📝 기타
- 스웨거 ui 에 자세하게 보여지도록 코드를 작성하려 하니, 스웨거 코드 덕지덕지...  읽기가 쉽지 않으실 것 같아요.
- 때문에 코드만 보기 보다는 직접 이 브랜치를 로컬로 가지고 와서 실행한 뒤, 
스웨거로 확인해 보는 것이 더 편하실수 있을것 같네요..ㅌㅋㅋㅌㅋ :D

