### PR TITLE
docs: 분실물 찾기(퀴즈, 서약) 기능 API 명세서 보완

### DIFF
--- a/src/main/java/com/greedy/zupzup/pledge/presentation/PledgeControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/pledge/presentation/PledgeControllerDocs.java
@@ -1,9 +1,13 @@
 package com.greedy.zupzup.pledge.presentation;
 
 import com.greedy.zupzup.auth.presentation.argumentresolver.LoginMember;
+import com.greedy.zupzup.global.exception.ErrorResponse;
 import com.greedy.zupzup.pledge.presentation.dto.PledgeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -22,9 +26,71 @@ public interface PledgeControllerDocs {
             security = @SecurityRequirement(name = "zupzupAccessTokenAuth")
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "서약 생성 성공"),
-            @ApiResponse(responseCode = "404", description = "요청한 분실물을 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "이미 서약이 완료되어 처리할 수 없음")
+            @ApiResponse(responseCode = "201", description = "서약 생성 성공",
+                    content = @Content(schema = @Schema(implementation = PledgeResponse.class),
+                            examples = @ExampleObject(name = "서약 생성 성공 예시", value = """
+                                    {
+                                        "pledgeId": 15,
+                                        "lostItemId": 101,
+                                        "ownerId": 2,
+                                        "pledgeDateTime": "2025-08-29T14:30:00"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "퀴즈가 필요한 분실물에 대해 퀴즈를 통과하지 않은 사용자가 서약을 시도한 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "퀴즈 미통과(미시도) 예시", value = """
+                                    {
+                                      "title": "퀴즈 미시도",
+                                      "status": 400,
+                                      "detail": "퀴즈를 통과하지 않아 서약을 진행할 수 없습니다.",
+                                      "instance": "/api/lost-items/101/pledges"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "요청에 포함된 액세스 토큰이 없거나 유효하지 않아 인증에 실패한 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "인증 실패 예시 (로그인 필요)", value = """
+                                    {
+                                      "title": "인증되지 않은 요청",
+                                      "status": 401,
+                                      "detail": "로그인이 필요합니다.",
+                                      "instance": "/api/lost-items/101/pledges"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "요청한 ID에 해당하는 분실물이 존재하지 않는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "분실물 없음 예시", value = """
+                                    {
+                                      "title": "분실물 없음",
+                                      "status": 404,
+                                      "detail": "해당 ID의 분실물을 찾을 수 없습니다.",
+                                      "instance": "/api/lost-items/101/pledges"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "409", description = "이미 서약되었거나 처리할 수 없는 상태의 분실물에 대해 서약을 시도하는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "서약 불가 상태 예시", value = """
+                                    {
+                                      "title": "서약 불가 상태",
+                                      "status": 409,
+                                      "detail": "이미 서약되었거나 처리할 수 없는 상태의 분실물입니다.",
+                                      "instance": "/api/lost-items/101/pledges"
+                                    }
+                                    """
+                            )
+                    )
+            )
     })
     ResponseEntity<PledgeResponse> createPledge(
             @Parameter(description = "서약할 분실물", required = true, example = "12")

--- a/src/main/java/com/greedy/zupzup/quiz/exception/QuizException.java
+++ b/src/main/java/com/greedy/zupzup/quiz/exception/QuizException.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum QuizException implements ExceptionCode {
 
     QUIZ_ATTEMPT_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "퀴즈 시도 횟수 초과", "퀴즈 시도 횟수를 초과하여 더 이상 시도할 수 없습니다."),
-    QUIZ_NOT_ATTEMPTED(HttpStatus.BAD_REQUEST, "퀴즈 미시도", "퀴즈를 시도하지 않아 서약을 진행할 수 없습니다.");
+    QUIZ_NOT_PASSED(HttpStatus.BAD_REQUEST, "퀴즈 미시도", "퀴즈를 통과하지 않아 서약을 진행할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String title;

--- a/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
+++ b/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
@@ -16,6 +16,6 @@ public interface QuizAttemptRepository extends JpaRepository<QuizAttempt, Long> 
 
     default QuizAttempt getByLostItemIdAndMemberId(Long lostItemId, Long memberId) {
         return findByLostItemIdAndMemberId(lostItemId, memberId)
-                .orElseThrow(() -> new ApplicationException(QuizException.QUIZ_NOT_ATTEMPTED));
+                .orElseThrow(() -> new ApplicationException(QuizException.QUIZ_NOT_PASSED));
     }
 }

--- a/src/test/java/com/greedy/zupzup/pledge/application/PledgeServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/pledge/application/PledgeServiceTest.java
@@ -132,11 +132,11 @@ class PledgeServiceTest extends ServiceUnitTest {
         given(memberRepository.getById(TEST_MEMBER_ID)).willReturn(member);
         given(lostItemRepository.getById(TEST_LOST_ITEM_ID)).willReturn(pledgeableLostItem);
         given(quizAttemptRepository.getByLostItemIdAndMemberId(TEST_LOST_ITEM_ID, TEST_MEMBER_ID))
-                .willThrow(new ApplicationException(QuizException.QUIZ_NOT_ATTEMPTED));
+                .willThrow(new ApplicationException(QuizException.QUIZ_NOT_PASSED));
 
         // when & then
         assertThatThrownBy(() -> pledgeService.createPledge(TEST_LOST_ITEM_ID, TEST_MEMBER_ID))
                 .isInstanceOf(ApplicationException.class)
-                .hasMessage(QuizException.QUIZ_NOT_ATTEMPTED.getDetail());
+                .hasMessage(QuizException.QUIZ_NOT_PASSED.getDetail());
     }
 }

--- a/src/test/java/com/greedy/zupzup/pledge/presentation/PledgeControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/pledge/presentation/PledgeControllerTest.java
@@ -123,7 +123,7 @@ class PledgeControllerTest extends ControllerTest {
             ErrorResponse response = extract.as(ErrorResponse.class);
             assertSoftly(softly -> {
                 softly.assertThat(extract.statusCode()).isEqualTo(400);
-                softly.assertThat(response.title()).isEqualTo(QuizException.QUIZ_NOT_ATTEMPTED.getTitle());
+                softly.assertThat(response.title()).isEqualTo(QuizException.QUIZ_NOT_PASSED.getTitle());
             });
         }
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
closed #61 

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
이슈 #13에서 구현한 퀴즈 및 서약 기능에 대한 ControllerDocs들을 리팩토링합니다.
- [X] QuizControllerDocs 리팩토링
- [X] PledgeControllerDocs 리팩토링

## ✅ 테스트
- [X] 수동 테스트 완료
- [X] 테스트 코드 완료
