### PR TITLE
fix: 기타 카테고리 대표 이미지 로직 수정

### DIFF
--- a/src/main/java/com/greedy/zupzup/category/domain/Category.java
+++ b/src/main/java/com/greedy/zupzup/category/domain/Category.java
@@ -43,7 +43,7 @@ public class Category extends BaseTimeEntity {
     @Builder.Default
     private List<Feature> features = new ArrayList<>();
 
-    public boolean isNotQuizCategory() {
+    public boolean isETCategory() {
         return ETC_CATEGORY_NAME.equals(this.name);
     }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemRegisterService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemRegisterService.java
@@ -48,7 +48,7 @@ public class LostItemRegisterService {
 
         Category category = getCategory(command.categoryId());
 
-        if (category.isNotQuizCategory()){
+        if (category.isETCategory()){
             return registETCLostItem(command, category);
         }
 

--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemViewService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemViewService.java
@@ -11,6 +11,7 @@ import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.lostitem.repository.RepresentativeImageProjection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,13 +47,11 @@ public class LostItemViewService {
 
         statusGuardForSimpleView(item);
 
-        String icon = (item.getCategory() != null) ? item.getCategory().getIconUrl() : "";
+        boolean isEtc = item.getCategory() != null
+                && "기타".equals(item.getCategory().getName());
 
-        boolean isEtc = item.isNotQuizCategory();
-        boolean hasIcon = icon != null && !icon.isBlank();
-
-        if (!isEtc && hasIcon) {
-            return LostItemSimpleViewCommand.of(item, icon);
+        if (!isEtc) {
+            return LostItemSimpleViewCommand.of(item, Objects.requireNonNull(item.getCategory()).getIconUrl());
         }
 
         String rep = getRepresentativeImageMapByItemIds(List.of(lostItemId))

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
@@ -2,7 +2,6 @@ package com.greedy.zupzup.lostitem.domain;
 
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.global.BaseTimeEntity;
-import com.greedy.zupzup.member.domain.Member;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -74,7 +73,7 @@ public class LostItem extends BaseTimeEntity {
     }
 
     public boolean isNotQuizCategory() {
-        return this.category.isNotQuizCategory();
+        return this.category.isETCategory();
     }
 
     public boolean isPledgeable() {

--- a/src/main/java/com/greedy/zupzup/lostitem/presentation/dto/LostItemViewResponse.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/presentation/dto/LostItemViewResponse.java
@@ -34,12 +34,11 @@ public record LostItemViewResponse(
     }
 
     public static LostItemViewResponse from(LostItemListCommand c, String representativeImageUrl) {
-        boolean iconPresent = c.categoryIconUrl() != null && !c.categoryIconUrl().isBlank();
-        boolean useRep = "기타".equals(c.categoryName()) || !iconPresent;
-
-        String finalImage = useRep
-                ? (representativeImageUrl != null ? representativeImageUrl : c.categoryIconUrl())
-                : c.categoryIconUrl();
+        String finalImage = "기타".equals(c.categoryName())
+                ? representativeImageUrl
+                : (c.categoryIconUrl() != null && !c.categoryIconUrl().isBlank()
+                        ? c.categoryIconUrl()
+                        : representativeImageUrl);
 
         return new LostItemViewResponse(
                 c.id(), c.categoryId(), c.categoryName(), c.categoryIconUrl(),
@@ -48,4 +47,6 @@ public record LostItemViewResponse(
                 finalImage
         );
     }
+
+
 }

--- a/src/test/java/com/greedy/zupzup/lostitem/presentation/LostItemViewControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/lostitem/presentation/LostItemViewControllerTest.java
@@ -64,7 +64,7 @@ class LostItemViewControllerTest extends ControllerTest {
         void 카테고리_이름이_기타면_목록_대표이미지는_0번_사진_URL_200_OK를_응답한다() {
             // given
             Category etc = givenEtcCategory();
-            ReflectionTestUtils.setField(etc, "iconUrl", "");
+            ReflectionTestUtils.setField(etc, "iconUrl", "https://icon.com/etc.svg");
             categoryRepository.saveAndFlush(etc);
 
             LostItem item = givenNonQuizLostItem(owner, etc);


### PR DESCRIPTION
## 📎 Issue 번호
closed #69

## ✨ 작업 내용
- 기타 카테고리 목록, 혹은 간단 조회 시 아이콘 url이 대표이미지로 들어가는 이슈해결

- 기존 조회 테스트 실패하던 거 수정
## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  

## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->

## ✅ 테스트
- [X] 수동 테스트 완료
- [X] 테스트 코드 완료
