### PR TITLE
fix: 용량이 큰 이미지 업로드 실패 해결

### DIFF
--- a/src/main/java/com/greedy/zupzup/global/infrastructure/S3ImageFileManager.java
+++ b/src/main/java/com/greedy/zupzup/global/infrastructure/S3ImageFileManager.java
@@ -23,7 +23,7 @@ public class S3ImageFileManager {
     private static final String PATH_DELIMITER = "/";
     private static final String FILE_EXTENSION_DELIMITER = ".";
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;     // 최대 이미지 크기 10MB
-    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif");
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "heic", "webp");
 
     private final S3Client s3Client;
     private final String bucketName;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,12 @@ server:
     session:
       timeout: ${STUDENT_VERIFICATION_SESSION_TIME:1m}
 
+spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB     # 개별 파일 최대 크기
+      max-request-size: 50MB  # 전체 요청 최대 크기
+
 cloud:
   aws:
     credentials:
@@ -30,4 +36,3 @@ zupzup:
       access:
         secret: ${ACCESS_TOKEN_SECRET_KEY:accessFSFvPh5v9x3w+T8fA9gB7eC6dF3gH5jJ2kL4mN1oP0rS1c}
         expiration-second: ${ACCESS_TOKEN_EXPIRATION:6000}  # 초 단위
-


### PR DESCRIPTION
## 📎 Issue 번호
- close: #71 

## ✨ 작업 내용
- 분실물 등록 API 호출 시 용량이 큰 이미지를 업로드 할때 요청이 실행되지 않는 문제를 해결했습니다.
- NginX 설정 수정:   
    - `/api/lost-items` 엔드포인트: 요청 Body의 최대 크기 50MB 설정    
    - `그 외`: 요청 Body의 최대 크기 1MB로 설정   
- 스프링 서버의 `application.yml`의 최대 요청 크기 설정도 추가했습니다.
- 저장 가능한 이미지 파일 확장자 heic, webp 를 추가했습니다.

## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  

## 📝 기타
- 기존에 `default.conf`파일에 설정했던 https 도메인 연결 설정들을 이번 수정 내용과 함께 새로운 conf 파일로 분리하였습니다.


## ✅ 테스트
- [x] 수동 테스트 완료
- [x] 테스트 코드 완료
