### PR TITLE
fix: 기타 카테고리 대표 사진 쿼리 수정

### DIFF
--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemImageRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemImageRepository.java
@@ -10,10 +10,16 @@ import org.springframework.data.repository.query.Param;
 public interface LostItemImageRepository extends JpaRepository<LostItemImage, Long> {
 
     @Query("""
-            select i.lostItem.id as lostItemId, i.imageKey as imageUrl
-            from LostItemImage i
-            where i.imageOrder = 0 and i.lostItem.id in :ids
-            """)
+        select i.lostItem.id as lostItemId,
+               coalesce(i.imageKey, '') as imageUrl
+          from LostItemImage i
+         where i.lostItem.id in :ids
+           and i.imageOrder = (
+                select min(i2.imageOrder)
+                  from LostItemImage i2
+                 where i2.lostItem.id = i.lostItem.id
+           )
+        """)
     List<RepresentativeImageProjection> findRepresentativeImages(@Param("ids") Collection<Long> ids);
 
     @Query("""


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
closed #73

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
0번째 순서의 사진으로 조회 시 대표이미지를 가지고 오지 못하는 문제 -> 가장 먼저인 것으로 조회하도록 쿼리를 수정했습니다.

## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  
제대로 확인 했어야 햇는데 자꾸 뒤늦게 추가적으로 수정해서 정말 죄송합니다!ㅜㅜㅜ
## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->

## ✅ 테스트
- [X] 수동 테스트 완료
- [X] 테스트 코드 완료
