### PR TITLE
refactor: 분실물 퀴즈 생성/제출 로직 개선, 중복 제출 오류 수정

### DIFF
--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemDetailViewService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemDetailViewService.java
@@ -39,7 +39,7 @@ public class LostItemDetailViewService {
         boolean pledgedByMe = pledgeRepository.existsByLostItem_IdAndOwner_Id(item.getId(), member.getId());
 
         boolean quizPassed = quizAttemptRepository
-                .existsByLostItem_IdAndMember_IdAndIsCorrectTrue(item.getId(), member.getId());
+                .existsByLostItemIdAndMemberIdAndIsCorrectTrue(item.getId(), member.getId());
 
         if (!item.canAccess(pledgedByMe)) {
             throw new ApplicationException(LostItemException.ACCESS_FORBIDDEN);
@@ -67,7 +67,7 @@ public class LostItemDetailViewService {
 
         boolean quizRequired = !item.isEtcCategory();
         boolean quizPassed = quizAttemptRepository
-                .existsByLostItem_IdAndMember_IdAndIsCorrectTrue(item.getId(), member.getId());
+                .existsByLostItemIdAndMemberIdAndIsCorrectTrue(item.getId(), member.getId());
 
         boolean pledgedByMe = pledgeRepository.existsByLostItem_IdAndOwner_Id(item.getId(), member.getId());
         if (!item.canAccess(pledgedByMe)) {
@@ -96,7 +96,7 @@ public class LostItemDetailViewService {
         boolean quizRequired = !item.isEtcCategory();
         boolean pledgedByMe = pledgeRepository.existsByLostItem_IdAndOwner_Id(item.getId(), member.getId());
         boolean quizPassed = quizAttemptRepository
-                .existsByLostItem_IdAndMember_IdAndIsCorrectTrue(item.getId(), member.getId());
+                .existsByLostItemIdAndMemberIdAndIsCorrectTrue(item.getId(), member.getId());
 
         if (!item.canAccess(pledgedByMe)) {
             throw new ApplicationException(LostItemException.ACCESS_FORBIDDEN);

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizGenerationService.java
@@ -41,12 +41,11 @@ public class QuizGenerationService {
         Member member = memberRepository.getById(memberId);
         LostItem lostItem = findAndValidateLostItem(lostItemId);
 
-        quizAttemptRepository.findByLostItemIdAndMemberId(lostItem.getId(), member.getId())
-                .ifPresent(attempt -> {
-                    if (!attempt.getIsCorrect()) {
-                        throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
-                    }
-                });
+        boolean hasIncorrectAttempt = quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(lostItem.getId(), member.getId());
+
+        if (hasIncorrectAttempt) {
+            throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
+        }
 
         if (lostItem.isEtcCategory()) {
             return Collections.emptyList();

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
@@ -15,6 +15,7 @@ import com.greedy.zupzup.quiz.exception.QuizException;
 import com.greedy.zupzup.quiz.repository.QuizAttemptRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,37 +38,46 @@ public class QuizSubmissionService {
         LostItem lostItem = lostItemRepository.getById(lostItemId);
         Member member = memberRepository.getById(memberId);
 
-        validateSubmissionPossibility(lostItem, member);
+        Optional<QuizAttempt> existingAttemptOpt = validateSubmissionPossibility(lostItem, member);
 
         List<LostItemFeature> correctFeatures = lostItemFeatureRepository.findWithFeatureAndOptionsByLostItemId(
                 lostItem.getId());
         Map<Long, Long> correctAnswerMap = createCorrectAnswerMap(correctFeatures);
         boolean isCorrect = checkAnswers(correctAnswerMap, answers, correctFeatures.size());
 
-        saveQuizAttempt(lostItem, member, isCorrect);
+        saveQuizAttempt(existingAttemptOpt, lostItem, member, isCorrect);
 
         return isCorrect ? QuizResultDto.correct(lostItem) : QuizResultDto.incorrect();
     }
 
-    private void validateSubmissionPossibility(LostItem lostItem, Member member) {
+    private Optional<QuizAttempt> validateSubmissionPossibility(LostItem lostItem, Member member) {
         if (!lostItem.isPledgeable()) {
             throw new ApplicationException(LostItemException.ALREADY_PLEDGED);
         }
 
-        boolean hasIncorrectAttempt = quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(lostItem.getId(), member.getId());
+        Optional<QuizAttempt> attemptOpt = quizAttemptRepository.findByLostItemIdAndMemberId(lostItem.getId(), member.getId());
 
-        if (hasIncorrectAttempt) {
-            throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
-        }
+        attemptOpt.ifPresent(attempt -> {
+            if (!attempt.getIsCorrect()) {
+                throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
+            }
+        });
+
+        return attemptOpt;
     }
 
-    private void saveQuizAttempt(LostItem lostItem, Member member, boolean isCorrect) {
-        QuizAttempt attempt = QuizAttempt.builder()
-                .member(member)
-                .lostItem(lostItem)
-                .isCorrect(isCorrect)
-                .build();
-        quizAttemptRepository.save(attempt);
+    private void saveQuizAttempt(Optional<QuizAttempt> existingAttemptOpt, LostItem lostItem, Member member, boolean isCorrect) {
+        if (existingAttemptOpt.isPresent()) {
+            QuizAttempt existingAttempt = existingAttemptOpt.get();
+            existingAttempt.updateResult(isCorrect);
+        } else {
+            QuizAttempt newAttempt = QuizAttempt.builder()
+                    .member(member)
+                    .lostItem(lostItem)
+                    .isCorrect(isCorrect)
+                    .build();
+            quizAttemptRepository.save(newAttempt);
+        }
     }
 
     private Map<Long, Long> createCorrectAnswerMap(List<LostItemFeature> correctFeatures) {

--- a/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
+++ b/src/main/java/com/greedy/zupzup/quiz/application/QuizSubmissionService.java
@@ -54,12 +54,11 @@ public class QuizSubmissionService {
             throw new ApplicationException(LostItemException.ALREADY_PLEDGED);
         }
 
-        quizAttemptRepository.findByLostItemIdAndMemberId(lostItem.getId(), member.getId())
-                .ifPresent(attempt -> {
-                    if (!attempt.getIsCorrect()) {
-                        throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
-                    }
-                });
+        boolean hasIncorrectAttempt = quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(lostItem.getId(), member.getId());
+
+        if (hasIncorrectAttempt) {
+            throw new ApplicationException(QuizException.QUIZ_ATTEMPT_LIMIT_EXCEEDED);
+        }
     }
 
     private void saveQuizAttempt(LostItem lostItem, Member member, boolean isCorrect) {

--- a/src/main/java/com/greedy/zupzup/quiz/domain/QuizAttempt.java
+++ b/src/main/java/com/greedy/zupzup/quiz/domain/QuizAttempt.java
@@ -42,4 +42,8 @@ public class QuizAttempt extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Boolean isCorrect;
+
+    public void updateResult(boolean isCorrect) {
+        this.isCorrect = isCorrect;
+    }
 }

--- a/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
+++ b/src/main/java/com/greedy/zupzup/quiz/repository/QuizAttemptRepository.java
@@ -10,7 +10,9 @@ public interface QuizAttemptRepository extends JpaRepository<QuizAttempt, Long> 
 
     boolean existsByLostItemIdAndMemberId(Long lostItemId, Long memberId);
 
-    boolean existsByLostItem_IdAndMember_IdAndIsCorrectTrue(Long lostItemId, Long memberId);
+    boolean existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(Long lostItemId, Long memberId);
+
+    boolean existsByLostItemIdAndMemberIdAndIsCorrectTrue(Long lostItemId, Long memberId);
 
     Optional<QuizAttempt> findByLostItemIdAndMemberId(Long lostItemId, Long memberId);
 

--- a/src/test/java/com/greedy/zupzup/lostitem/application/LostItemDetailViewServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/lostitem/application/LostItemDetailViewServiceTest.java
@@ -71,7 +71,7 @@ class LostItemDetailViewServiceTest extends ServiceUnitTest {
         @Test
         void 퀴즈_통과시_200_OK를_응답합니다() {
             given(lostItemRepository.getWithCategoryAndAreaById(ITEM_ID)).willReturn(전자기기_서약미완료);
-            given(quizAttemptRepository.existsByLostItem_IdAndMember_IdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
+            given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
                     .willReturn(true);
 
             LostItemDetailViewCommand result = service.getImagesAfterQuiz(ITEM_ID, MEMBER_ID);
@@ -85,7 +85,7 @@ class LostItemDetailViewServiceTest extends ServiceUnitTest {
         @Test
         void 퀴즈_미통과면_403_FORBIDDEN를_응답합니다() {
             given(lostItemRepository.getWithCategoryAndAreaById(ITEM_ID)).willReturn(전자기기_서약완료);
-            given(quizAttemptRepository.existsByLostItem_IdAndMember_IdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
+            given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
                     .willReturn(false);
 
             assertThatThrownBy(() -> service.getImagesAfterQuiz(ITEM_ID, MEMBER_ID))
@@ -116,7 +116,7 @@ class LostItemDetailViewServiceTest extends ServiceUnitTest {
         void 퀴즈_통과_및_서약완료면_보관위치와_200_OK를_응답합니다() {
             given(lostItemRepository.getWithCategoryAndAreaById(ITEM_ID)).willReturn(전자기기_서약완료);
             given(pledgeRepository.existsByLostItem_IdAndOwner_Id(ITEM_ID, MEMBER_ID)).willReturn(true);
-            given(quizAttemptRepository.existsByLostItem_IdAndMember_IdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
+            given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
                     .willReturn(true);
 
             String area = service.getDepositArea(ITEM_ID, MEMBER_ID);
@@ -157,7 +157,7 @@ class LostItemDetailViewServiceTest extends ServiceUnitTest {
         void 퀴즈_통과_및_서약완료면_200_OK를_응답합니다() {
             given(lostItemRepository.getWithCategoryAndAreaById(ITEM_ID)).willReturn(전자기기_서약완료);
             given(pledgeRepository.existsByLostItem_IdAndOwner_Id(ITEM_ID, MEMBER_ID)).willReturn(true);
-            given(quizAttemptRepository.existsByLostItem_IdAndMember_IdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
+            given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
                     .willReturn(true);
 
             LostItemDetailViewCommand result = service.getDetail(ITEM_ID, MEMBER_ID);
@@ -170,7 +170,7 @@ class LostItemDetailViewServiceTest extends ServiceUnitTest {
         void 서약만_했고_퀴즈미통과면_403_FORBIDDEN을_응답합니다() {
             given(lostItemRepository.getWithCategoryAndAreaById(ITEM_ID)).willReturn(전자기기_서약완료);
             given(pledgeRepository.existsByLostItem_IdAndOwner_Id(ITEM_ID, MEMBER_ID)).willReturn(true);
-            given(quizAttemptRepository.existsByLostItem_IdAndMember_IdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
+            given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectTrue(ITEM_ID, MEMBER_ID))
                     .willReturn(false);
 
             assertThatThrownBy(() -> service.getDetail(ITEM_ID, MEMBER_ID))

--- a/src/test/java/com/greedy/zupzup/quiz/application/QuizGenerationServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/quiz/application/QuizGenerationServiceTest.java
@@ -66,7 +66,7 @@ class QuizGenerationServiceTest extends ServiceUnitTest {
 
         given(memberRepository.getById(TEST_MEMBER_ID)).willReturn(member);
         given(lostItemRepository.getWithCategoryById(TEST_LOST_ITEM_ID)).willReturn(pledgeableLostItem);
-        given(quizAttemptRepository.findByLostItemIdAndMemberId(anyLong(), anyLong())).willReturn(Optional.empty());
+        given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(anyLong(), anyLong())).willReturn(false);
         given(lostItemFeatureRepository.findWithFeatureAndOptionsByLostItemId(TEST_LOST_ITEM_ID)).willReturn(
                 mockFeatures);
 
@@ -85,7 +85,7 @@ class QuizGenerationServiceTest extends ServiceUnitTest {
 
         then(memberRepository).should().getById(TEST_MEMBER_ID);
         then(lostItemRepository).should().getWithCategoryById(TEST_LOST_ITEM_ID);
-        then(quizAttemptRepository).should().findByLostItemIdAndMemberId(anyLong(), anyLong());
+        then(quizAttemptRepository).should().existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(anyLong(), anyLong());
         then(lostItemFeatureRepository).should().findWithFeatureAndOptionsByLostItemId(TEST_LOST_ITEM_ID);
     }
 
@@ -110,12 +110,9 @@ class QuizGenerationServiceTest extends ServiceUnitTest {
     void 이미_퀴즈를_틀린_기록이_있는_경우_예외가_발생해야_한다() {
 
         // given
-        QuizAttempt incorrectQuizAttempt = INCORRECT_QUIZ_ATTEMPT(member, pledgeableLostItem);
-
         given(memberRepository.getById(TEST_MEMBER_ID)).willReturn(member);
         given(lostItemRepository.getWithCategoryById(TEST_LOST_ITEM_ID)).willReturn(pledgeableLostItem);
-        given(quizAttemptRepository.findByLostItemIdAndMemberId(anyLong(), anyLong())).willReturn(
-                Optional.of(incorrectQuizAttempt));
+        given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(anyLong(), anyLong())).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> quizGenerationService.getLostItemQuizzes(TEST_LOST_ITEM_ID, TEST_MEMBER_ID))
@@ -130,7 +127,7 @@ class QuizGenerationServiceTest extends ServiceUnitTest {
         // given
         given(memberRepository.getById(TEST_MEMBER_ID)).willReturn(member);
         given(lostItemRepository.getWithCategoryById(ETC_CATEGORY_LOST_ITEM_ID)).willReturn(nonQuizCategoryLostItem);
-        given(quizAttemptRepository.findByLostItemIdAndMemberId(anyLong(), anyLong())).willReturn(Optional.empty());
+        given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(anyLong(), anyLong())).willReturn(false);
 
         // when
         List<QuizDto> result = quizGenerationService.getLostItemQuizzes(ETC_CATEGORY_LOST_ITEM_ID, TEST_MEMBER_ID);
@@ -148,7 +145,7 @@ class QuizGenerationServiceTest extends ServiceUnitTest {
 
         given(memberRepository.getById(TEST_MEMBER_ID)).willReturn(member);
         given(lostItemRepository.getWithCategoryById(TEST_LOST_ITEM_ID)).willReturn(pledgeableLostItem);
-        given(quizAttemptRepository.findByLostItemIdAndMemberId(anyLong(), anyLong())).willReturn(Optional.empty());
+        given(quizAttemptRepository.existsByLostItemIdAndMemberIdAndIsCorrectIsFalse(anyLong(), anyLong())).willReturn(false);
         given(lostItemFeatureRepository.findWithFeatureAndOptionsByLostItemId(TEST_LOST_ITEM_ID)).willReturn(
                 mockFeatures);
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
closed #76 

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- 사용자가 퀴즈를 생성하고 정답을 맞춘 후 서약을 작성하지 않고 다시 퀴즈 생성을 할 경우 이전 정답이 맞았다면 다시 제출을 할 수 있게끔 수정했습니다.
- 기존의 QuizGenerationService에서 findByLostItemIdAndMemberId가 아닌 existsByLostItemIdAndMemberId를 사용하도록 수정했습니다.
- 해당 부분에 대한 test 코드를 추가하였습니다.

## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  

## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->
원래는 서약에서는 동일하게 find를 사용하구 QuizService에 있는 findByLostItemIdAndMemberId들을 existsByLostItemIdAndMemberId로 수정하기로 했었어요!  정답 제출 서비스에서 한번 QuizAttempt를 save한 후에는 다시 시도하는 경우는 update하는 걸로 수정해야 했어서 쿼리를 두번 날리는 것 보다 find를 쓰는 게 좋을 것 같아 퀴즈 생성 서비스에서만 변경하도록 했습니다.

## ✅ 테스트
- [X] 수동 테스트 완료
- [X] 테스트 코드 완료
