### PR TITLE
refactor: 캐싱을 통한 조회 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,39 +24,49 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testImplementation 'io.rest-assured:rest-assured:5.4.0'
 
+	// Spring Boot 기본 스타터
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+	// DB & JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.hibernate.orm:hibernate-spatial'
 	implementation 'org.locationtech.jts:jts-core'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// API 문서화 - Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// 인프라 & 외부 연동
 	implementation 'software.amazon.awssdk:s3:2.25.11'
-
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-
-    implementation 'org.springframework.boot:spring-boot-starter-aop' // AOP
-    implementation 'net.logstash.logback:logstash-logback-encoder:8.0' // logback
-
-	// 포털 로그인 위한 의존성
 	implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 	implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.3'
 	implementation 'org.jsoup:jsoup:1.15.3'
 
-	// jwt
+	// 보안 & 인증
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'
-
-	// 비밀번호 암호화
 	implementation 'org.mindrot:jbcrypt:0.4'
+
+	// 로깅
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+
+	// 캐싱
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// 테스트
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.rest-assured:rest-assured:5.4.0'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/greedy/zupzup/ZupzupApplication.java
+++ b/src/main/java/com/greedy/zupzup/ZupzupApplication.java
@@ -2,10 +2,12 @@ package com.greedy.zupzup;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@EnableCaching
 @EnableJpaAuditing
+@SpringBootApplication
 public class ZupzupApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/greedy/zupzup/category/application/CategoryService.java
+++ b/src/main/java/com/greedy/zupzup/category/application/CategoryService.java
@@ -38,6 +38,7 @@ public class CategoryService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = CacheType.CacheNames.CATEGORY_DETAILS, key = "#categoryId")
     public CategoryFeaturesResponse getCategoryFeatures(Long categoryId) {
         Category category = categoryRepository.findWithFeaturesById(categoryId)
                 .orElseThrow(() -> new ApplicationException(CategoryException.CATEGORY_NOT_FOUND));

--- a/src/main/java/com/greedy/zupzup/category/application/CategoryService.java
+++ b/src/main/java/com/greedy/zupzup/category/application/CategoryService.java
@@ -11,10 +11,12 @@ import com.greedy.zupzup.category.presentation.dto.CategoriesResponse;
 import com.greedy.zupzup.category.presentation.dto.CategoryFeaturesResponse;
 import com.greedy.zupzup.category.repository.CategoryRepository;
 import com.greedy.zupzup.category.repository.FeatureOptionRepository;
+import com.greedy.zupzup.global.config.CacheType;
 import com.greedy.zupzup.global.exception.ApplicationException;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,7 @@ public class CategoryService {
     private final FeatureOptionRepository featureOptionRepository;
 
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = CacheType.CacheNames.ALL_CATEGORY, key = "'all'")
     public CategoriesResponse getAll() {
         List<CategoryDto> list = categoryRepository.findAllByOrderByIdAsc()
                 .stream()

--- a/src/main/java/com/greedy/zupzup/global/config/CacheConfig.java
+++ b/src/main/java/com/greedy/zupzup/global/config/CacheConfig.java
@@ -1,0 +1,37 @@
+package com.greedy.zupzup.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        List<CaffeineCache> cacheList = getCaffeineCaches();
+        cacheManager.setCaches(cacheList);
+        return cacheManager;
+    }
+
+    private List<CaffeineCache> getCaffeineCaches() {
+        return Arrays.stream(CacheType.values())
+                .map(cache -> new CaffeineCache(
+                                cache.getCacheName(),
+                                Caffeine.newBuilder()
+                                        .recordStats()
+                                        .expireAfterWrite(cache.getExpiredAfterWrite(), cache.getTimeUnit())
+                                        .maximumSize(cache.getMaximumSize())
+                                        .build()
+                        )
+                )
+                .toList();
+    }
+}

--- a/src/main/java/com/greedy/zupzup/global/config/CacheType.java
+++ b/src/main/java/com/greedy/zupzup/global/config/CacheType.java
@@ -1,0 +1,25 @@
+package com.greedy.zupzup.global.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@AllArgsConstructor
+public enum CacheType {
+
+    ALL_SCHOOL_AREA(CacheNames.ALL_SCHOOL_AREA, 3, TimeUnit.DAYS, 1),
+    ;
+
+
+    public static final class CacheNames {
+        public static final String ALL_SCHOOL_AREA = "school-area-all";
+    }
+
+    private final String cacheName;
+    private final int expiredAfterWrite;
+    private final TimeUnit timeUnit;
+    private final int maximumSize;
+
+}

--- a/src/main/java/com/greedy/zupzup/global/config/CacheType.java
+++ b/src/main/java/com/greedy/zupzup/global/config/CacheType.java
@@ -10,11 +10,13 @@ import java.util.concurrent.TimeUnit;
 public enum CacheType {
 
     ALL_SCHOOL_AREA(CacheNames.ALL_SCHOOL_AREA, 3, TimeUnit.DAYS, 1),
+    ALL_CATEGORY(CacheNames.ALL_CATEGORY, 3, TimeUnit.DAYS, 1),
     ;
 
 
     public static final class CacheNames {
-        public static final String ALL_SCHOOL_AREA = "school-area-all";
+        public static final String ALL_SCHOOL_AREA = "all-school-area";
+        public static final String ALL_CATEGORY = "all-category";
     }
 
     private final String cacheName;

--- a/src/main/java/com/greedy/zupzup/global/config/CacheType.java
+++ b/src/main/java/com/greedy/zupzup/global/config/CacheType.java
@@ -11,12 +11,13 @@ public enum CacheType {
 
     ALL_SCHOOL_AREA(CacheNames.ALL_SCHOOL_AREA, 3, TimeUnit.DAYS, 1),
     ALL_CATEGORY(CacheNames.ALL_CATEGORY, 3, TimeUnit.DAYS, 1),
+    CATEGORY_DETAILS(CacheNames.CATEGORY_DETAILS, 3, TimeUnit.DAYS, 20),
     ;
-
 
     public static final class CacheNames {
         public static final String ALL_SCHOOL_AREA = "all-school-area";
         public static final String ALL_CATEGORY = "all-category";
+        public static final String CATEGORY_DETAILS = "category-details";
     }
 
     private final String cacheName;

--- a/src/main/java/com/greedy/zupzup/schoolarea/application/SchoolAreaService.java
+++ b/src/main/java/com/greedy/zupzup/schoolarea/application/SchoolAreaService.java
@@ -1,5 +1,6 @@
 package com.greedy.zupzup.schoolarea.application;
 
+import com.greedy.zupzup.global.config.CacheType;
 import com.greedy.zupzup.schoolarea.application.dto.FindAreaCommand;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import com.greedy.zupzup.schoolarea.repository.SchoolAreaRepository;
@@ -8,6 +9,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,7 @@ public class SchoolAreaService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = CacheType.CacheNames.ALL_SCHOOL_AREA, key = "'all'")
     public List<SchoolArea> findAllAreas() {
         return schoolAreaRepository.findAll();
     }

--- a/src/test/java/com/greedy/zupzup/category/presentation/CategoryControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/category/presentation/CategoryControllerTest.java
@@ -7,6 +7,7 @@ import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.presentation.dto.CategoriesResponse;
 import com.greedy.zupzup.category.presentation.dto.CategoryFeaturesResponse;
 import com.greedy.zupzup.common.ControllerTest;
+import com.greedy.zupzup.global.config.CacheType;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -16,17 +17,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
 
 
 class CategoryControllerTest extends ControllerTest {
 
     private Category electronics;
     private Category wallet;
+    private Cache allCategoryCache;
+    private Cache categoryDetailsCache;
 
     @BeforeEach
     void setUp() {
         electronics = givenElectronicsCategory();
         wallet = givenWalletCategory();
+        allCategoryCache = cacheManager.getCache(CacheType.ALL_CATEGORY.getCacheName());
+        categoryDetailsCache = cacheManager.getCache(CacheType.CATEGORY_DETAILS.getCacheName());
+        allCategoryCache.clear();
+        categoryDetailsCache.clear();
     }
 
     @Nested
@@ -34,7 +42,7 @@ class CategoryControllerTest extends ControllerTest {
     class GetAll {
 
         @Test
-        void 카테고리를_전체_조회하면_200_OK와_카테고리_목록을_응답한다() {
+        void 카테고리를_전체_조회하면_200_OK와_카테고리_목록을_응답해야_한다() {
             // when
             ExtractableResponse<Response> extract = RestAssured.given().log().all()
                     .when()
@@ -59,6 +67,42 @@ class CategoryControllerTest extends ControllerTest {
                 softly.assertThat(response.categories().get(0).iconUrl()).isNotBlank();
             });
         }
+
+        @Test
+        void 두_번_이상_카테고리_전체를_조회하면_캐싱된_데이터를_응답해야_한다() {
+            // given
+            String cacheKey = "all";
+            assertThat(allCategoryCache.get(cacheKey)).isNull();
+
+            // when
+            CategoriesResponse firstResponse = RestAssured.given().log().all()
+                    .when()
+                    .get("/api/categories")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(CategoriesResponse.class);
+
+            CategoriesResponse secondResponse = RestAssured.given().log().all()
+                    .when()
+                    .get("/api/categories")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(CategoriesResponse.class);
+
+            // then
+            com.github.benmanes.caffeine.cache.Cache caffeineCache
+                    = (com.github.benmanes.caffeine.cache.Cache) allCategoryCache.getNativeCache();
+
+            assertSoftly(softly -> {
+                assertThat(secondResponse.categories().size()).isEqualTo(firstResponse.categories().size());
+                assertThat(secondResponse.categories()).containsAll(firstResponse.categories());
+                assertThat(caffeineCache.stats().hitCount()).isEqualTo(1L);
+                assertThat(allCategoryCache.get(cacheKey)).isNotNull();
+            });
+        }
+
     }
 
     @Nested
@@ -66,7 +110,7 @@ class CategoryControllerTest extends ControllerTest {
     class GetCategoryFeaturesAndOptions {
 
         @Test
-        void 카테고리ID로_특징과_옵션을_조회하면_200_OK와_목록을_응답한다() {
+        void 카테고리ID로_특징과_옵션을_조회하면_200_OK와_목록을_응답해야_한다() {
             // when
             ExtractableResponse<Response> extract = RestAssured.given().log().all()
                     .when()
@@ -98,7 +142,7 @@ class CategoryControllerTest extends ControllerTest {
         }
 
         @Test
-        void 존재하지_않는_카테고리ID로_요청하면_404_Not_Found를_응답한다() {
+        void 존재하지_않는_카테고리ID로_요청하면_404_Not_Found를_응답해야_한다() {
             long nonExistentId = 999_999L;
 
             ExtractableResponse<Response> extract = RestAssured.given().log().all()
@@ -111,7 +155,7 @@ class CategoryControllerTest extends ControllerTest {
         }
 
         @Test
-        void 숫자가_아닌_카테고리ID면_400_BAD_REQUEST를_응답한다() {
+        void 숫자가_아닌_카테고리ID면_400_BAD_REQUEST를_응답해야_한다() {
             ExtractableResponse<Response> extract = RestAssured.given().log().all()
                     .when()
                     .get("/api/categories/{categoryId}/features", "abc")
@@ -120,5 +164,44 @@ class CategoryControllerTest extends ControllerTest {
 
             assertThat(extract.statusCode()).isEqualTo(400);
         }
+
+        @Test
+        void 두_번_이상_카테고리_특징옵션을_조회하면_캐싱된_데이터를_응답해야_한다() {
+            // given
+            Long categoryId = electronics.getId();
+            Long cacheKey = categoryId;
+
+            assertThat(categoryDetailsCache.get(cacheKey)).isNull();
+
+            // when
+            CategoryFeaturesResponse firstResponse = RestAssured.given().log().all()
+                    .when()
+                    .get("/api/categories/{categoryId}/features", categoryId)
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(CategoryFeaturesResponse.class);
+
+            CategoryFeaturesResponse secondResponse = RestAssured.given().log().all()
+                    .when()
+                    .get("/api/categories/{categoryId}/features", categoryId)
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(CategoryFeaturesResponse.class);
+
+            // then
+            com.github.benmanes.caffeine.cache.Cache caffeineCache
+                    = (com.github.benmanes.caffeine.cache.Cache) categoryDetailsCache.getNativeCache();
+
+            assertSoftly(softly -> {
+                assertThat(secondResponse.categoryId()).isEqualTo(firstResponse.categoryId());
+                assertThat(secondResponse.features()).containsAll(firstResponse.features());
+                assertThat(caffeineCache.stats().hitCount()).isEqualTo(1L);
+                assertThat(categoryDetailsCache.get(cacheKey)).isNotNull();
+            });
+        }
+
     }
+
 }

--- a/src/test/java/com/greedy/zupzup/common/ControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/common/ControllerTest.java
@@ -9,7 +9,6 @@ import com.greedy.zupzup.category.repository.FeatureOptionRepository;
 import com.greedy.zupzup.category.repository.FeatureRepository;
 import com.greedy.zupzup.common.fixture.CategoryFixture;
 import com.greedy.zupzup.common.fixture.LostItemImageFixture;
-import com.greedy.zupzup.common.fixture.MemberFixture;
 import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
@@ -27,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
@@ -75,6 +75,9 @@ public abstract class ControllerTest {
 
     @Autowired
     protected JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    protected CacheManager cacheManager;
 
     @LocalServerPort
     protected int port;

--- a/src/test/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/schoolarea/presentation/SchoolAreaControllerTest.java
@@ -1,6 +1,7 @@
 package com.greedy.zupzup.schoolarea.presentation;
 
 import com.greedy.zupzup.common.ControllerTest;
+import com.greedy.zupzup.global.config.CacheType;
 import com.greedy.zupzup.global.exception.CommonException;
 import com.greedy.zupzup.global.exception.ErrorResponse;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
@@ -14,6 +15,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.http.MediaType;
 
 import java.util.List;
@@ -24,10 +28,13 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 class SchoolAreaControllerTest extends ControllerTest {
 
     private List<SchoolArea> schoolAreas;
+    private Cache schoolAreaCache;
 
     @BeforeEach
     void setUp() {
         schoolAreas = givenSchoolAreas();
+        schoolAreaCache = cacheManager.getCache(CacheType.ALL_SCHOOL_AREA.getCacheName());
+        schoolAreaCache.clear();
     }
 
     @Nested
@@ -48,6 +55,45 @@ class SchoolAreaControllerTest extends ControllerTest {
 
             // then
             assertThat(response.count()).isEqualTo(schoolAreas.size());
+        }
+
+        @Test
+        void 두_번_이상_모든_학교_구역조회에_성공하면_캐싱된_데이터를_응답해야_한다() {
+
+            String cacheKey = "all";
+
+            assertThat(schoolAreaCache.get(cacheKey)).isNull();
+
+            // given & when
+            AllSchoolAreasResponse firstResponse = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .when()
+                    .get("/api/school-areas")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(AllSchoolAreasResponse.class);
+
+            AllSchoolAreasResponse secondResponse = RestAssured.given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .when()
+                    .get("/api/school-areas")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(AllSchoolAreasResponse.class);
+
+            // then
+            com.github.benmanes.caffeine.cache.Cache caffeineCache
+                    = (com.github.benmanes.caffeine.cache.Cache) schoolAreaCache.getNativeCache();
+
+            assertSoftly(softly -> {
+                assertThat(secondResponse.count()).isEqualTo(firstResponse.count());
+                assertThat(secondResponse.schoolAreas()).containsAll(firstResponse.schoolAreas());
+                assertThat(caffeineCache.stats().hitCount()).isEqualTo(1L);
+                assertThat(schoolAreaCache.get(cacheKey)).isNotNull();      // 캐시 객체에서 해당 키가 존재하는지 확인하는 작업도 캐시 hit에 포함됨
+            });
+
         }
     }
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->

- closed: #89 

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- 빈번하게 조회되지만, 거의 수정되지 않는 `학교 구역`, `카테고리 관련` 데이터를 조회하는 API를 캐싱을 통해 조회 성능을 개선하였습니다.

- JVM 힙 영역의 메모리를 사용하는 `로컬 캐시 (Caffeine)`을 캐시 저장소로 사용하여 구현하였습니다.
(캐시 저장소 선택 이유에 대한 자세한 내용은 노션에 정리해 두었어요)

- 캐싱된 데이터를 응답하는지에 대한 `인수 테스트`를 작성했습니다.

## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  

## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->

- 현재 캐싱 데이터의 TTL은 모두 `3일`로 설정을 해 두었습니다. (더 길게 할까요? 짧게 할까요? 의견 주세요!)


<br>

### [결과]
로컬 환경에서 서버의 처리 시간을 비교 측정한 결과, 다음과 같이 서버의 처리 속도가 개선되었습니다.

- 학교 구역 전체 조회 API: `429ms` -> `16ms`    
   <img width="70%" height="70%" alt="image" src="https://github.com/user-attachments/assets/2f171c7b-148e-48a2-bd6d-b664fc93ea18" />


- 카테고리 전체 조회 API: `83ms` -> `6ms`  
  <img width="70%" height="70%" alt="image" src="https://github.com/user-attachments/assets/a739e278-0cbb-48d3-9137-5818dbab5f1f" />

- 카테고리 특징 및 옵션 조회 API: `175ms` -> `25ms`  
  <img width="70%" height="70%" alt="image" src="https://github.com/user-attachments/assets/6101465f-52eb-48f5-9dab-0cb9fc6fc1bc" />



## ✅ 테스트
- [x] 수동 테스트 완료
- [x] 테스트 코드 완료
