### PR TITLE
chore: 운영 환경 설정 분리

### DIFF
--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -3,7 +3,7 @@ name: zupzup CI/CD with GitHub Actions
 on:
   push:
     branches:
-      - main
+      - chxghee/chore-56-cookie
 
 jobs:
   deploy:

--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -3,7 +3,7 @@ name: zupzup CI/CD with GitHub Actions
 on:
   push:
     branches:
-      - chxghee/chore-56-cookie
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -3,7 +3,7 @@ name: zupzup CI/CD with GitHub Actions
 on:
   push:
     branches:
-      - main
+      - chxnghee/chore-56-cookie
 
 jobs:
   deploy:
@@ -91,3 +91,4 @@ jobs:
             
             /home/ubuntu/zupzup/script/deploy.sh
             
+

--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -3,7 +3,7 @@ name: zupzup CI/CD with GitHub Actions
 on:
   push:
     branches:
-      - chxnghee/chore-56-cookie
+      - chxghee/chore-56-cookie
 
 jobs:
   deploy:

--- a/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/AuthController.java
@@ -31,6 +31,7 @@ public class AuthController implements AuthControllerDocs {
     private static final String SEJONG_VERIFICATION_INFO_SESSION_KEY = "sejongAuthInfo";
 
     private final AuthService authService;
+    private final CookieUtil cookieUtil;
     private final JwtTokenProvider jwtTokenProvider;
 
 
@@ -80,7 +81,7 @@ public class AuthController implements AuthControllerDocs {
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletResponse response) {
-        CookieUtil.setToken("", 0, response);
+        cookieUtil.setToken("", 0, response);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -97,7 +98,7 @@ public class AuthController implements AuthControllerDocs {
 
     private void setAccessToken(HttpServletResponse response, Member member) {
         String accessToken = jwtTokenProvider.createAccessToken(member);
-        CookieUtil.setToken(accessToken, jwtTokenProvider.accessExpirationSecond, response);
+        cookieUtil.setToken(accessToken, jwtTokenProvider.accessExpirationSecond, response);
     }
 
 }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/argumentresolver/LoginMemberArgumentResolver.java
@@ -17,6 +17,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtil cookieUtil;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -38,7 +39,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     private LoginMember getLoginMemberFromAccessToken(HttpServletRequest request) {
-        String accessToken = CookieUtil.extractToken(request.getCookies());
+        String accessToken = cookieUtil.extractToken(request.getCookies());
         Long loginMemberId = jwtTokenProvider.getLoginMemberId(accessToken);
         return new LoginMember(loginMemberId);
     }

--- a/src/main/java/com/greedy/zupzup/auth/presentation/interceptor/AdminInterceptor.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/interceptor/AdminInterceptor.java
@@ -22,6 +22,7 @@ public class AdminInterceptor implements HandlerInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final CookieUtil cookieUtil;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -31,7 +32,7 @@ public class AdminInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String accessToken = CookieUtil.extractToken(request.getCookies());
+        String accessToken = cookieUtil.extractToken(request.getCookies());
         Long loginMemberId = jwtTokenProvider.getLoginMemberId(accessToken);
 
         if (!memberRepository.existsByIdAndRole(loginMemberId, Role.ADMIN)) {

--- a/src/main/java/com/greedy/zupzup/auth/presentation/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/greedy/zupzup/auth/presentation/interceptor/AuthInterceptor.java
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class AuthInterceptor implements HandlerInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtil cookieUtil;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -24,7 +25,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String accessToken = CookieUtil.extractToken(request.getCookies());
+        String accessToken = cookieUtil.extractToken(request.getCookies());
         Long loginMemberId = jwtTokenProvider.getLoginMemberId(accessToken);
 
         if (loginMemberId == null) {

--- a/src/main/java/com/greedy/zupzup/global/config/WebConfig.java
+++ b/src/main/java/com/greedy/zupzup/global/config/WebConfig.java
@@ -5,6 +5,7 @@ import com.greedy.zupzup.auth.presentation.interceptor.AdminInterceptor;
 import com.greedy.zupzup.auth.presentation.interceptor.AuthInterceptor;
 import com.greedy.zupzup.global.presentation.interceptor.LogInterceptor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -22,13 +23,8 @@ public class WebConfig implements WebMvcConfigurer {
     private final AdminInterceptor adminInterceptor;
     private final AuthInterceptor authInterceptor;
 
-    private static final String[] ALLOWED_ORIGINS = {
-            "https://api.sejong-zupzup.kr", // 메인 API 서버
-            "https://www.sejong-zupzup.kr",
-            "https://sejong-zupzup.kr",
-            "http://localhost:5173",
-            "http://localhost:4173"
-    };
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -63,7 +59,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins(ALLOWED_ORIGINS)
+                .allowedOrigins(allowedOrigins.toArray(new String[0]))
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
+++ b/src/main/java/com/greedy/zupzup/global/util/CookieUtil.java
@@ -4,25 +4,51 @@ import com.greedy.zupzup.auth.exception.AuthException;
 import com.greedy.zupzup.global.exception.ApplicationException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
+@Component
 public class CookieUtil {
 
     private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
 
-    public static void setToken(String accessToken, int cookieExpirationSeconds, HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .maxAge(cookieExpirationSeconds)
-                .sameSite("None")   // Lux 로 변경
-                .build();
+    private final String cookieDomain;
+    private final boolean cookieSecure;
+    private final String cookieSameSite;
 
-        response.addHeader("Set-Cookie", cookie.toString());
+    public CookieUtil(@Value("${jwt.cookie.domain}") String cookieDomain,
+                      @Value("${jwt.cookie.secure}") boolean cookieSecure,
+                      @Value("${jwt.cookie.samesite}") String cookieSameSite) {
+        this.cookieDomain = cookieDomain;
+        this.cookieSecure = cookieSecure;
+        this.cookieSameSite = cookieSameSite;
     }
 
-    public static String extractToken(Cookie[] cookies) {
+    public void setToken(String accessToken, int cookieExpirationSeconds, HttpServletResponse response) {
+        ResponseCookie cookie = createCookie(accessToken, cookieExpirationSeconds);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private ResponseCookie createCookie(String value, int maxAge) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, value)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(maxAge)
+                .sameSite(cookieSameSite);
+
+        // 도메인 설정이 있을 경우에만 적용 (.zupzup.com 등)
+        if (StringUtils.hasText(cookieDomain)) {
+            builder.domain(cookieDomain);
+        }
+
+        return builder.build();
+    }
+
+    public String extractToken(Cookie[] cookies) {
         if (cookies == null) {
             throw new ApplicationException(AuthException.UNAUTHENTICATED_REQUEST);
         }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,12 @@ spring:
       hibernate:
         format_sql: true
 
+jwt:
+  cookie:
+    domain: ""
+    secure: false
+    samesite: Lax
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,9 @@ spring:
       hibernate:
         format_sql: true
 
+cors:
+  allowed-origins: "https://sejong-zupzup.kr, https://www.sejong-zupzup.kr, https://api.sejong-zupzup.kr, http://localhost:5173, http://localhost:4173"
+
 jwt:
   cookie:
     domain: ""

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,9 @@ spring:
     hibernate:
       ddl-auto: validate
 
+cors:
+  allowed-origins: "https://sejong-zupzup.kr, https://www.sejong-zupzup.kr, https://api.sejong-zupzup.kr"
+
 jwt:
   cookie:
     domain: .sejong-zupzup.kr

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,12 @@ spring:
     hibernate:
       ddl-auto: validate
 
+jwt:
+  cookie:
+    domain: .sejong-zupzup.kr
+    secure: true
+    samesite: Lax
+
 management:
   endpoints:
     web:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,6 +13,12 @@ spring:
       hibernate:
         format_sql: true
 
+jwt:
+  cookie:
+    domain: null
+    secure: false
+    samesite: Lax
+
 logging:
   level:
     org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl: error

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,6 +12,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+cors:
+  allowed-origins: "https://sejong-zupzup.kr, https://www.sejong-zupzup.kr, https://api.sejong-zupzup.kr, http://localhost:5173, http://localhost:4173"
 
 jwt:
   cookie:


### PR DESCRIPTION
## 📎 Issue 번호

## ✨ 작업 내용

### 1. 보안을 위한 Cookie 설정 변경
- **Domain 설정 추가 (`.sejong-zupzup.kr`)**
  - 서브 도메인(`api`)과 메인 도메인(`www`) 간의 로그인 쿠키 공유를 위해, 상위 도메인을 기준으로 쿠키가 발급되도록 수정했습니다..
  
- **SameSite 설정 변경 (`None` -> `Lax`)**
  - CSRF 보안 취약점 개선: 기존 SameSite=None 설정은 제3의 악성 사이트(해커 사이트)에서 우리 서버로 요청을 보낼 때도 인증 쿠키가 함께 전송되는 위험이 있었습니다.
  - Lax 적용: 이를 Lax로 변경하여, 타 사이트에서 발생하는 POST 요청(상태 변경 시도)에는 쿠키가 전송되지 않도록 차단하고, 프론트/백엔드 간 통신(Same-Site)에서만 쿠키를 허용하여 보안을 강화해 보았습니다.




### 2. 환경별(Profile) CORS 정책 분리 적용
- **운영(Prod) 환경:** 실제 배포된 프론트엔드 도메인(`https://sejong-zupzup.kr` 등)만 허용하여 보안을 강화했습니다.
- **개발(Dev/Local) 환경:** 프론트엔드 로컬 개발을 지원하기 위해 `localhost` 대역(`4173`, `5173` 등)을 허용하도록 분리했습니다. (아직 데브 서버는 따로 띄우지 않았습니다.)
- 설정 파일(`yml`)을 통해 환경별 `allowed-origins` 값을 주입받도록 구조를 개선했습니다.


## 🎯 리뷰 포인트

## 📝 기타
### 프론트엔드 로컬 개발 관련... (중요)

- 이번 CORS 정책 분리를 하게 된다면, **프론트엔드 로컬(`localhost`)에서 운영 서버 API(`api.sejong-zupzup.kr`)를 직접 호출하는 것이 차단**됩니다.
- 이는 추후 개발 서버를 따로 배포 하던가, 프론트 로컬에 백엔드 서버를 띄울수 있게 하면 될듯 싶은데요,
- 이와 관련하여 논의가 필요할것 같슴니다. (분리 할지 말지..?)


## ✅ 테스트
- [x] 수동 테스트 완료
- [x] 테스트 코드 완료