### PR TITLE
feat: 관리자 페이지 분실물 수정 기능 구현

### DIFF
--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -9,7 +9,7 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
+import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemCommand;
 import com.greedy.zupzup.admin.lostitem.repository.AdminLostItemRepository;
 import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.lostitem.application.LostItemStorageService;

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -1,7 +1,7 @@
 package com.greedy.zupzup.admin.lostitem.application;
 
-import com.greedy.zupzup.admin.lostitem.application.dto.AdminFeatureOptionDto;
-import com.greedy.zupzup.admin.lostitem.application.dto.AdminLostItemResult;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.LostItemFeatureOptionDto;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminLostItemDto;
 import com.greedy.zupzup.admin.lostitem.application.dto.ItemImageBulkDeletedEvent;
 import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemResult;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminPendingLostItemListResponse;
@@ -12,8 +12,6 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse
 import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
 import com.greedy.zupzup.admin.lostitem.repository.AdminLostItemRepository;
 import com.greedy.zupzup.global.exception.ApplicationException;
-import com.greedy.zupzup.global.infrastructure.S3FileCleanupService;
-import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
 import com.greedy.zupzup.lostitem.application.LostItemStorageService;
 import com.greedy.zupzup.lostitem.application.dto.LostItemRegisterData;
 import com.greedy.zupzup.lostitem.application.dto.UploadedImageData;
@@ -23,12 +21,10 @@ import com.greedy.zupzup.lostitem.domain.LostItemStatus;
 import com.greedy.zupzup.lostitem.exception.LostItemException;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
@@ -83,10 +79,10 @@ public class AdminLostItemService {
         List<Long> ids = extractIds(items);
 
         Map<Long, List<String>> imageMap = loadImageMap(ids);
-        Map<Long, List<AdminFeatureOptionDto>> featureMap = loadFeatureMap(ids);
+        Map<Long, List<LostItemFeatureOptionDto>> featureMap = loadFeatureMap(ids);
 
-        List<AdminLostItemResult> results =
-                AdminLostItemResult.fromList(items, imageMap, featureMap);
+        List<AdminLostItemDto> results =
+                AdminLostItemDto.fromList(items, imageMap, featureMap);
         return AdminPendingLostItemListResponse.of(results, page, limit, results.size());
     }
 
@@ -180,11 +176,11 @@ public class AdminLostItemService {
                 ));
     }
 
-    private Map<Long, List<AdminFeatureOptionDto>> loadFeatureMap(List<Long> ids) {
+    private Map<Long, List<LostItemFeatureOptionDto>> loadFeatureMap(List<Long> ids) {
         return lostItemFeatureRepository.findFeaturesForLostItems(ids).stream()
                 .collect(Collectors.groupingBy(
                         lf -> lf.getLostItem().getId(),
-                        Collectors.mapping(lf -> AdminFeatureOptionDto.of(lf.getSelectedOption()), Collectors.toList())
+                        Collectors.mapping(lf -> LostItemFeatureOptionDto.of(lf.getSelectedOption()), Collectors.toList())
                 ));
     }
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -3,26 +3,24 @@ package com.greedy.zupzup.admin.lostitem.application;
 import com.greedy.zupzup.admin.lostitem.application.dto.AdminFeatureOptionDto;
 import com.greedy.zupzup.admin.lostitem.application.dto.AdminLostItemResult;
 import com.greedy.zupzup.admin.lostitem.application.dto.ItemImageBulkDeletedEvent;
+import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemResult;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminPendingLostItemListResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
 import com.greedy.zupzup.admin.lostitem.repository.AdminLostItemRepository;
 import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.global.infrastructure.S3FileCleanupService;
 import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
 import com.greedy.zupzup.lostitem.application.LostItemStorageService;
-import com.greedy.zupzup.lostitem.application.dto.CreateLostItemCommand;
 import com.greedy.zupzup.lostitem.application.dto.LostItemRegisterData;
 import com.greedy.zupzup.lostitem.application.dto.UploadedImageData;
 import com.greedy.zupzup.lostitem.domain.LostItem;
-import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.domain.LostItemImage;
 import com.greedy.zupzup.lostitem.domain.LostItemStatus;
 import com.greedy.zupzup.lostitem.exception.LostItemException;
-import com.greedy.zupzup.lostitem.exception.LostItemImageException;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import java.util.Collections;
@@ -47,10 +45,6 @@ public class AdminLostItemService {
     private final LostItemFeatureRepository lostItemFeatureRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final LostItemStorageService lostItemStorageService;
-    private final S3ImageFileManager s3ImageFileManager;
-    private final S3FileCleanupService s3FileCleanupService;
-
-    private static final String IMAGE_DIRECTORY = "lost-item-images";
 
     @Transactional
     public ApproveLostItemsResponse approveBulk(ApproveLostItemsRequest request) {
@@ -90,152 +84,78 @@ public class AdminLostItemService {
         Map<Long, List<String>> imageMap = loadImageMap(ids);
         Map<Long, List<AdminFeatureOptionDto>> featureMap = loadFeatureMap(ids);
 
-        List<AdminLostItemResult> commands = buildCommands(items, imageMap, featureMap);
+        List<AdminLostItemResult> results =
+                AdminLostItemResult.fromList(items, imageMap, featureMap);
+        return AdminPendingLostItemListResponse.of(results, page, limit, results.size());
+    }
 
-        return AdminPendingLostItemListResponse.of(commands, page, limit, commands.size());
+    public UpdateLostItemResult updateLostItem(Long lostItemId,
+                                               UpdateLostItemCommand command,
+                                               List<Long> keepImageIds,
+                                               List<MultipartFile> newImages) {
+
+        List<UploadedImageData> uploadedImages =
+                lostItemStorageService.uploadImages(newImages);
+
+        try {
+            return updateLostItemTx(
+                    lostItemId,
+                    command,
+                    keepImageIds,
+                    uploadedImages
+            );
+        } catch (Exception e) {
+            lostItemStorageService.cleanupImages(uploadedImages);
+            throw e;
+        }
     }
 
     @Transactional
-    public void updateLostItem(Long lostItemId,
-                               UpdateLostItemRequest request,
-                               List<Long> keepImageIds,
-                               List<MultipartFile> newImages) {
+    public UpdateLostItemResult updateLostItemTx(Long lostItemId,
+                                                 UpdateLostItemCommand command,
+                                                 List<Long> keepImageIds,
+                                                 List<UploadedImageData> uploadedImages) {
 
         LostItem lostItem = findPendingLostItem(lostItemId);
 
-        validateImageCount(keepImageIds, newImages);
+        List<LostItemImage> existingImages =
+                lostItemImageRepository.findByLostItemId(lostItemId);
 
-        LostItemRegisterData validData = getValidatedRegisterData(request);
+        validateImageOwnershipInMemory(existingImages, keepImageIds);
 
-        List<UploadedImageData> uploadedNewImages = syncImages(lostItem, keepImageIds, newImages);
+        LostItemRegisterData validData =
+                lostItemStorageService.getValidUpdateData(command);
 
-        try {
-            updateDomainInfo(lostItem, request, validData);
-            updateFeatures(lostItem, validData);
+        lostItemStorageService.updateLostItem(
+                lostItem,
+                command,
+                validData,
+                keepImageIds,
+                uploadedImages,
+                existingImages
+        );
 
-            lostItem.approve();
+        return UpdateLostItemResult.from(lostItemId);
+    }
 
-        } catch (Exception e) {
-            cleanupNewlyUploadedImages(uploadedNewImages);
-            throw e;
+
+    private void validateImageOwnershipInMemory(List<LostItemImage> existingImages, List<Long> keepImageIds) {
+        if (keepImageIds == null || keepImageIds.isEmpty()) {
+            return;
+        }
+        List<Long> existingIds = existingImages.stream().map(LostItemImage::getId).toList();
+        if (!existingIds.containsAll(keepImageIds)) {
+            throw new ApplicationException(LostItemException.INVALID_IMAGE_ACCESS);
         }
     }
 
     private LostItem findPendingLostItem(Long lostItemId) {
         LostItem lostItem = adminLostItemRepository.findById(lostItemId)
                 .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
-
         if (lostItem.getStatus() != LostItemStatus.PENDING) {
             throw new ApplicationException(LostItemException.ACCESS_FORBIDDEN);
         }
         return lostItem;
-    }
-
-    private void validateImageCount(List<Long> keepImageIds, List<MultipartFile> newImages) {
-        int keepCount = (keepImageIds == null) ? 0 : keepImageIds.size();
-        int newCount = (newImages == null) ? 0 : newImages.size();
-        if (keepCount + newCount < 1) {
-            throw new ApplicationException(LostItemImageException.INVALID_IMAGE_COUNT);
-        }
-    }
-
-    private LostItemRegisterData getValidatedRegisterData(UpdateLostItemRequest request) {
-        CreateLostItemCommand dummyCommand = new CreateLostItemCommand(
-                request.description(),
-                request.depositArea(),
-                request.foundAreaId(),
-                request.foundAreaDetail(),
-                request.categoryId(),
-                CreateLostItemCommand.toItemFeatureOptionList(request.featureOptions()),
-                List.of()
-        );
-        return lostItemStorageService.getValidRegisterData(dummyCommand);
-    }
-
-    private List<UploadedImageData> syncImages(LostItem lostItem, List<Long> keepImageIds, List<MultipartFile> newImages) {
-        List<LostItemImage> existingImages = lostItemImageRepository.findByLostItemId(lostItem.getId());
-        List<Long> safeKeepIds = (keepImageIds == null) ? List.of() : keepImageIds;
-
-        validateImageOwnership(lostItem.getId(), safeKeepIds);
-
-        deleteExcludedImages(existingImages, safeKeepIds);
-
-        return uploadAndSaveNewImages(lostItem, newImages);
-    }
-
-    private void validateImageOwnership(Long lostItemId, List<Long> safeKeepIds) {
-        if (!safeKeepIds.isEmpty()) {
-            long count = lostItemImageRepository.countByIdInAndLostItemId(safeKeepIds, lostItemId);
-            if (count != safeKeepIds.size()) {
-                throw new ApplicationException(LostItemException.INVALID_IMAGE_ACCESS);
-            }
-        }
-    }
-
-    private void deleteExcludedImages(List<LostItemImage> existingImages, List<Long> safeKeepIds) {
-        List<LostItemImage> toDelete = existingImages.stream()
-                .filter(img -> !safeKeepIds.contains(img.getId()))
-                .toList();
-
-        if (!toDelete.isEmpty()) {
-            lostItemImageRepository.deleteAll(toDelete);
-            s3FileCleanupService.cleanupOrphanFiles(
-                    toDelete.stream().map(LostItemImage::getImageKey).toList()
-            );
-        }
-    }
-
-    private List<UploadedImageData> uploadAndSaveNewImages(LostItem lostItem, List<MultipartFile> newImages) {
-        if (newImages == null || newImages.isEmpty()) {
-            return List.of();
-        }
-
-        List<UploadedImageData> uploaded = uploadNewImages(newImages);
-        lostItemImageRepository.saveAll(
-                uploaded.stream()
-                        .map(data -> LostItemImage.of(lostItem, data.url(), data.order()))
-                        .toList()
-        );
-        return uploaded;
-    }
-
-    private void updateDomainInfo(LostItem lostItem, UpdateLostItemRequest request, LostItemRegisterData validData) {
-        lostItem.updateInfo(
-                request.description(),
-                request.depositArea(),
-                validData.foundSchoolArea(),
-                request.foundAreaDetail(),
-                validData.category()
-        );
-    }
-
-    private void cleanupNewlyUploadedImages(List<UploadedImageData> uploadedNewImages) {
-        if (!uploadedNewImages.isEmpty()) {
-            s3FileCleanupService.cleanupOrphanFiles(
-                    uploadedNewImages.stream().map(UploadedImageData::url).toList()
-            );
-        }
-    }
-
-    private List<UploadedImageData> uploadNewImages(List<MultipartFile> images) {
-        if (images == null || images.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return IntStream.range(0, images.size())
-                .mapToObj(i -> {
-                    String url = s3ImageFileManager.upload(images.get(i), IMAGE_DIRECTORY);
-                    return new UploadedImageData(url, i);
-                }).toList();
-    }
-
-    private void updateFeatures(LostItem lostItem, LostItemRegisterData validData) {
-        lostItemFeatureRepository.deleteByLostItemIds(List.of(lostItem.getId()));
-        if (validData.isNonETC()) {
-            List<LostItemFeature> newFeatures = validData.itemFeatureAndOptions().stream()
-                    .map(pair -> LostItemFeature.of(lostItem, pair.getFirst(), pair.getSecond()))
-                    .toList();
-            lostItemFeatureRepository.saveAll(newFeatures);
-        }
     }
 
     private List<LostItem> findPendingItems(Pageable pageable) {
@@ -243,9 +163,7 @@ public class AdminLostItemService {
     }
 
     private List<Long> extractIds(List<LostItem> items) {
-        return items.stream()
-                .map(LostItem::getId)
-                .toList();
+        return items.stream().map(LostItem::getId).toList();
     }
 
     private Map<Long, List<String>> loadImageMap(List<Long> ids) {
@@ -260,32 +178,7 @@ public class AdminLostItemService {
         return lostItemFeatureRepository.findFeaturesForLostItems(ids).stream()
                 .collect(Collectors.groupingBy(
                         lf -> lf.getLostItem().getId(),
-                        Collectors.mapping(
-                                lf -> AdminFeatureOptionDto.of(lf.getSelectedOption()),
-                                Collectors.toList()
-                        )
+                        Collectors.mapping(lf -> AdminFeatureOptionDto.of(lf.getSelectedOption()), Collectors.toList())
                 ));
-    }
-
-    private List<AdminLostItemResult> buildCommands(
-            List<LostItem> items,
-            Map<Long, List<String>> imageMap,
-            Map<Long, List<AdminFeatureOptionDto>> featureMap
-    ) {
-        return items.stream()
-                .map(item -> new AdminLostItemResult(
-                        item.getId(),
-                        item.getCategory().getId(),
-                        item.getCategory().getName(),
-                        item.getFoundArea().getId(),
-                        item.getFoundArea().getAreaName(),
-                        item.getFoundAreaDetail(),
-                        item.getCreatedAt().toString(),
-                        item.getDescription(),
-                        item.getDepositArea(),
-                        imageMap.getOrDefault(item.getId(), Collections.emptyList()),
-                        featureMap.getOrDefault(item.getId(), Collections.emptyList())
-                ))
-                .toList();
     }
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -26,12 +26,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminLostItemService {
@@ -110,12 +112,15 @@ public class AdminLostItemService {
 
         } catch (Exception e) {
             lostItemStorageService.cleanupImages(uploadedImages);
-            throw e;
+            log.error("분실물 DB 수정 실패. S3 롤백", e);
+            throw new ApplicationException(LostItemException.UPDATE_FAILED);
         }
     }
 
     private void validateImageOwnership(List<LostItemImage> existingImages, List<Long> keepImageIds) {
-        if (keepImageIds == null || keepImageIds.isEmpty()) return;
+        if (keepImageIds == null || keepImageIds.isEmpty()) {
+            return;
+        }
         Set<Long> existingIds = existingImages.stream()
                 .map(LostItemImage::getId)
                 .collect(Collectors.toSet());
@@ -153,7 +158,8 @@ public class AdminLostItemService {
         return lostItemFeatureRepository.findFeaturesForLostItems(ids).stream()
                 .collect(Collectors.groupingBy(
                         lf -> lf.getLostItem().getId(),
-                        Collectors.mapping(lf -> LostItemFeatureOptionDto.of(lf.getSelectedOption()), Collectors.toList())
+                        Collectors.mapping(lf -> LostItemFeatureOptionDto.of(lf.getSelectedOption()),
+                                Collectors.toList())
                 ));
     }
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -14,7 +14,6 @@ import com.greedy.zupzup.global.exception.ApplicationException;
 import com.greedy.zupzup.global.infrastructure.S3FileCleanupService;
 import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
 import com.greedy.zupzup.lostitem.application.LostItemStorageService;
-import com.greedy.zupzup.lostitem.application.dto.CreateImageCommand;
 import com.greedy.zupzup.lostitem.application.dto.CreateLostItemCommand;
 import com.greedy.zupzup.lostitem.application.dto.LostItemRegisterData;
 import com.greedy.zupzup.lostitem.application.dto.UploadedImageData;
@@ -23,13 +22,14 @@ import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.domain.LostItemImage;
 import com.greedy.zupzup.lostitem.domain.LostItemStatus;
 import com.greedy.zupzup.lostitem.exception.LostItemException;
-import com.greedy.zupzup.lostitem.presentation.dto.LostItemRegisterRequest;
+import com.greedy.zupzup.lostitem.exception.LostItemImageException;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
@@ -101,92 +101,131 @@ public class AdminLostItemService {
                                List<Long> keepImageIds,
                                List<MultipartFile> newImages) {
 
+        LostItem lostItem = findPendingLostItem(lostItemId);
+
+        validateImageCount(keepImageIds, newImages);
+
+        LostItemRegisterData validData = getValidatedRegisterData(request);
+
+        List<UploadedImageData> uploadedNewImages = syncImages(lostItem, keepImageIds, newImages);
+
+        try {
+            updateDomainInfo(lostItem, request, validData);
+            updateFeatures(lostItem, validData);
+
+            lostItem.approve();
+
+        } catch (Exception e) {
+            cleanupNewlyUploadedImages(uploadedNewImages);
+            throw e;
+        }
+    }
+
+    private LostItem findPendingLostItem(Long lostItemId) {
         LostItem lostItem = adminLostItemRepository.findById(lostItemId)
                 .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
 
         if (lostItem.getStatus() != LostItemStatus.PENDING) {
             throw new ApplicationException(LostItemException.ACCESS_FORBIDDEN);
         }
+        return lostItem;
+    }
 
-        CreateLostItemCommand dummyCommand = CreateLostItemCommand.of(
-                new LostItemRegisterRequest(
-                        request.description(),
-                        request.depositArea(),
-                        request.foundAreaId(),
-                        request.foundAreaDetail(),
-                        request.categoryId(),
-                        request.featureOptions()
-                ),
-                Collections.emptyList()
+    private void validateImageCount(List<Long> keepImageIds, List<MultipartFile> newImages) {
+        int keepCount = (keepImageIds == null) ? 0 : keepImageIds.size();
+        int newCount = (newImages == null) ? 0 : newImages.size();
+        if (keepCount + newCount < 1) {
+            throw new ApplicationException(LostItemImageException.INVALID_IMAGE_COUNT);
+        }
+    }
+
+    private LostItemRegisterData getValidatedRegisterData(UpdateLostItemRequest request) {
+        CreateLostItemCommand dummyCommand = new CreateLostItemCommand(
+                request.description(),
+                request.depositArea(),
+                request.foundAreaId(),
+                request.foundAreaDetail(),
+                request.categoryId(),
+                CreateLostItemCommand.toItemFeatureOptionList(request.featureOptions()),
+                List.of()
         );
+        return lostItemStorageService.getValidRegisterData(dummyCommand);
+    }
 
-        LostItemRegisterData validData =
-                lostItemStorageService.getValidRegisterData(dummyCommand);
-
-        List<LostItemImage> existingImages =
-                lostItemImageRepository.findByLostItemId(lostItemId);
-
+    private List<UploadedImageData> syncImages(LostItem lostItem, List<Long> keepImageIds, List<MultipartFile> newImages) {
+        List<LostItemImage> existingImages = lostItemImageRepository.findByLostItemId(lostItem.getId());
         List<Long> safeKeepIds = (keepImageIds == null) ? List.of() : keepImageIds;
 
+        validateImageOwnership(lostItem.getId(), safeKeepIds);
+
+        deleteExcludedImages(existingImages, safeKeepIds);
+
+        return uploadAndSaveNewImages(lostItem, newImages);
+    }
+
+    private void validateImageOwnership(Long lostItemId, List<Long> safeKeepIds) {
         if (!safeKeepIds.isEmpty()) {
-            long count = lostItemImageRepository
-                    .countByIdInAndLostItemId(safeKeepIds, lostItemId);
+            long count = lostItemImageRepository.countByIdInAndLostItemId(safeKeepIds, lostItemId);
             if (count != safeKeepIds.size()) {
                 throw new ApplicationException(LostItemException.INVALID_IMAGE_ACCESS);
             }
         }
+    }
 
+    private void deleteExcludedImages(List<LostItemImage> existingImages, List<Long> safeKeepIds) {
         List<LostItemImage> toDelete = existingImages.stream()
                 .filter(img -> !safeKeepIds.contains(img.getId()))
                 .toList();
 
-        List<UploadedImageData> uploadedNewImages = List.of();
-
-        try {
-            if (!toDelete.isEmpty()) {
-                lostItemImageRepository.deleteAll(toDelete);
-                s3FileCleanupService.cleanupOrphanFiles(
-                        toDelete.stream().map(LostItemImage::getImageKey).toList()
-                );
-            }
-
-            if (newImages != null && !newImages.isEmpty()) {
-                uploadedNewImages = uploadNewImages(newImages);
-                lostItemImageRepository.saveAll(
-                        uploadedNewImages.stream()
-                                .map(data -> LostItemImage.of(lostItem, data.url(), data.order()))
-                                .toList()
-                );
-            }
-
-            lostItem.updateInfo(
-                    request.description(),
-                    request.depositArea(),
-                    validData.foundSchoolArea(),
-                    request.foundAreaDetail(),
-                    validData.category()
+        if (!toDelete.isEmpty()) {
+            lostItemImageRepository.deleteAll(toDelete);
+            s3FileCleanupService.cleanupOrphanFiles(
+                    toDelete.stream().map(LostItemImage::getImageKey).toList()
             );
+        }
+    }
 
-            updateFeatures(lostItem, validData);
+    private List<UploadedImageData> uploadAndSaveNewImages(LostItem lostItem, List<MultipartFile> newImages) {
+        if (newImages == null || newImages.isEmpty()) {
+            return List.of();
+        }
 
-            lostItem.approve();
+        List<UploadedImageData> uploaded = uploadNewImages(newImages);
+        lostItemImageRepository.saveAll(
+                uploaded.stream()
+                        .map(data -> LostItemImage.of(lostItem, data.url(), data.order()))
+                        .toList()
+        );
+        return uploaded;
+    }
 
-        } catch (Exception e) {
-            if (!uploadedNewImages.isEmpty()) {
-                s3FileCleanupService.cleanupOrphanFiles(
-                        uploadedNewImages.stream().map(UploadedImageData::url).toList()
-                );
-            }
-            throw e;
+    private void updateDomainInfo(LostItem lostItem, UpdateLostItemRequest request, LostItemRegisterData validData) {
+        lostItem.updateInfo(
+                request.description(),
+                request.depositArea(),
+                validData.foundSchoolArea(),
+                request.foundAreaDetail(),
+                validData.category()
+        );
+    }
+
+    private void cleanupNewlyUploadedImages(List<UploadedImageData> uploadedNewImages) {
+        if (!uploadedNewImages.isEmpty()) {
+            s3FileCleanupService.cleanupOrphanFiles(
+                    uploadedNewImages.stream().map(UploadedImageData::url).toList()
+            );
         }
     }
 
     private List<UploadedImageData> uploadNewImages(List<MultipartFile> images) {
-        List<CreateImageCommand> imageCommands = CreateLostItemCommand.toCreateImageCommandListWithValidation(images);
-        return imageCommands.stream()
-                .map(img -> new UploadedImageData(s3ImageFileManager.upload(img.imageFile(), IMAGE_DIRECTORY),
-                        img.order()))
-                .toList();
+        if (images == null || images.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return IntStream.range(0, images.size())
+                .mapToObj(i -> {
+                    String url = s3ImageFileManager.upload(images.get(i), IMAGE_DIRECTORY);
+                    return new UploadedImageData(url, i);
+                }).toList();
     }
 
     private void updateFeatures(LostItem lostItem, LostItemRegisterData validData) {

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -31,7 +31,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -86,66 +85,40 @@ public class AdminLostItemService {
         return AdminPendingLostItemListResponse.of(results, page, limit, results.size());
     }
 
-    public UpdateLostItemResult updateLostItem(Long lostItemId,
-                                               UpdateLostItemCommand command,
-                                               List<MultipartFile> newImages) {
+    public UpdateLostItemResult updateLostItem(UpdateLostItemCommand command) {
 
-        List<UploadedImageData> uploadedImages =
-                lostItemStorageService.uploadImages(newImages);
+        LostItem lostItem = findPendingLostItem(command.lostItemId());
+        List<LostItemImage> existingImages = lostItemImageRepository.findByLostItemId(command.lostItemId());
+        validateImageOwnership(existingImages, command.keepImageIds());
+
+        LostItemRegisterData validatedData = lostItemStorageService.getValidUpdateData(command);
+
+        List<UploadedImageData> uploadedImages = lostItemStorageService.uploadImages(command.newImages());
 
         try {
-            return updateLostItemTx(
-                    lostItemId,
+            List<String> oldKeysToDelete = lostItemStorageService.updateInTransaction(
+                    lostItem,
                     command,
-                    uploadedImages
+                    validatedData,
+                    uploadedImages,
+                    existingImages
             );
+
+            lostItemStorageService.deleteOldImages(oldKeysToDelete);
+
+            return UpdateLostItemResult.from(command.lostItemId());
+
         } catch (Exception e) {
             lostItemStorageService.cleanupImages(uploadedImages);
             throw e;
         }
     }
 
-    @Transactional
-    public UpdateLostItemResult updateLostItemTx(Long lostItemId,
-                                                 UpdateLostItemCommand command,
-                                                 List<UploadedImageData> uploadedImages) {
-
-        LostItem lostItem = findPendingLostItem(lostItemId);
-
-        List<LostItemImage> existingImages =
-                lostItemImageRepository.findByLostItemId(lostItemId);
-
-        List<Long> keepImageIds = command.keepImageIds();
-
-        validateImageOwnershipInMemory(existingImages, keepImageIds);
-
-        LostItemRegisterData validData =
-                lostItemStorageService.getValidUpdateData(command);
-
-        lostItemStorageService.updateLostItem(
-                lostItem,
-                command,
-                validData,
-                keepImageIds,
-                uploadedImages,
-                existingImages
-        );
-
-        return UpdateLostItemResult.from(lostItemId);
-    }
-
-    private void validateImageOwnershipInMemory(
-            List<LostItemImage> existingImages,
-            List<Long> keepImageIds
-    ) {
-        if (keepImageIds == null || keepImageIds.isEmpty()) {
-            return;
-        }
-
+    private void validateImageOwnership(List<LostItemImage> existingImages, List<Long> keepImageIds) {
+        if (keepImageIds == null || keepImageIds.isEmpty()) return;
         Set<Long> existingIds = existingImages.stream()
                 .map(LostItemImage::getId)
                 .collect(Collectors.toSet());
-
         if (!existingIds.containsAll(keepImageIds)) {
             throw new ApplicationException(LostItemException.INVALID_IMAGE_ACCESS);
         }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -8,10 +8,22 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
 import com.greedy.zupzup.admin.lostitem.repository.AdminLostItemRepository;
+import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.global.infrastructure.S3FileCleanupService;
+import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
+import com.greedy.zupzup.lostitem.application.LostItemStorageService;
+import com.greedy.zupzup.lostitem.application.dto.CreateImageCommand;
+import com.greedy.zupzup.lostitem.application.dto.CreateLostItemCommand;
+import com.greedy.zupzup.lostitem.application.dto.LostItemRegisterData;
+import com.greedy.zupzup.lostitem.application.dto.UploadedImageData;
 import com.greedy.zupzup.lostitem.domain.LostItem;
+import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.domain.LostItemImage;
 import com.greedy.zupzup.lostitem.domain.LostItemStatus;
+import com.greedy.zupzup.lostitem.exception.LostItemException;
+import com.greedy.zupzup.lostitem.presentation.dto.LostItemRegisterRequest;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import java.util.Collections;
@@ -24,6 +36,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +46,11 @@ public class AdminLostItemService {
     private final LostItemImageRepository lostItemImageRepository;
     private final LostItemFeatureRepository lostItemFeatureRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final LostItemStorageService lostItemStorageService;
+    private final S3ImageFileManager s3ImageFileManager;
+    private final S3FileCleanupService s3FileCleanupService;
+
+    private static final String IMAGE_DIRECTORY = "lost-item-images";
 
     @Transactional
     public ApproveLostItemsResponse approveBulk(ApproveLostItemsRequest request) {
@@ -75,6 +93,79 @@ public class AdminLostItemService {
         List<AdminLostItemResult> commands = buildCommands(items, imageMap, featureMap);
 
         return AdminPendingLostItemListResponse.of(commands, page, limit, commands.size());
+    }
+
+    @Transactional
+    public void updateLostItem(Long lostItemId, UpdateLostItemRequest request, List<MultipartFile> images) {
+
+        LostItem lostItem = adminLostItemRepository.findById(lostItemId)
+                .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
+
+        CreateLostItemCommand dummyCommand = CreateLostItemCommand.of(
+                new LostItemRegisterRequest(request.description(), request.depositArea(),
+                        request.foundAreaId(), request.foundAreaDetail(),
+                        request.categoryId(), request.featureOptions()),
+                Collections.emptyList()
+        );
+        LostItemRegisterData validData = lostItemStorageService.getValidRegisterData(dummyCommand);
+
+        List<String> oldImageUrls = lostItemImageRepository.findImageKeysByLostItemIds(List.of(lostItemId));
+        List<UploadedImageData> newUploadedImages = Collections.emptyList();
+
+        if (images != null && !images.isEmpty()) {
+            newUploadedImages = uploadNewImages(images);
+            updateImages(lostItem, newUploadedImages);
+        }
+
+        try {
+            lostItem.updateInfo(
+                    request.description(),
+                    request.depositArea(),
+                    validData.foundSchoolArea(),
+                    request.foundAreaDetail(),
+                    validData.category()
+            );
+
+            updateFeatures(lostItem, validData);
+            lostItem.approve();
+
+            if (!newUploadedImages.isEmpty()) {
+                s3FileCleanupService.cleanupOrphanFiles(oldImageUrls);
+            }
+
+        } catch (Exception e) {
+            if (!newUploadedImages.isEmpty()) {
+                List<String> currentUploadedUrls = newUploadedImages.stream().map(UploadedImageData::url).toList();
+                s3FileCleanupService.cleanupOrphanFiles(currentUploadedUrls);
+            }
+            throw e;
+        }
+    }
+
+    private List<UploadedImageData> uploadNewImages(List<MultipartFile> images) {
+        List<CreateImageCommand> imageCommands = CreateLostItemCommand.toCreateImageCommandListWithValidation(images);
+        return imageCommands.stream()
+                .map(img -> new UploadedImageData(s3ImageFileManager.upload(img.imageFile(), IMAGE_DIRECTORY),
+                        img.order()))
+                .toList();
+    }
+
+    private void updateImages(LostItem lostItem, List<UploadedImageData> uploadedImages) {
+        lostItemImageRepository.deleteByLostItemIds(List.of(lostItem.getId()));
+        List<LostItemImage> newImageEntities = uploadedImages.stream()
+                .map(data -> LostItemImage.of(lostItem, data.url(), data.order()))
+                .toList();
+        lostItemImageRepository.saveAll(newImageEntities);
+    }
+
+    private void updateFeatures(LostItem lostItem, LostItemRegisterData validData) {
+        lostItemFeatureRepository.deleteByLostItemIds(List.of(lostItem.getId()));
+        if (validData.isNonETC()) {
+            List<LostItemFeature> newFeatures = validData.itemFeatureAndOptions().stream()
+                    .map(pair -> LostItemFeature.of(lostItem, pair.getFirst(), pair.getSecond()))
+                    .toList();
+            lostItemFeatureRepository.saveAll(newFeatures);
+        }
     }
 
     private List<LostItem> findPendingItems(Pageable pageable) {

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -26,6 +26,7 @@ import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -91,7 +92,6 @@ public class AdminLostItemService {
 
     public UpdateLostItemResult updateLostItem(Long lostItemId,
                                                UpdateLostItemCommand command,
-                                               List<Long> keepImageIds,
                                                List<MultipartFile> newImages) {
 
         List<UploadedImageData> uploadedImages =
@@ -101,7 +101,6 @@ public class AdminLostItemService {
             return updateLostItemTx(
                     lostItemId,
                     command,
-                    keepImageIds,
                     uploadedImages
             );
         } catch (Exception e) {
@@ -113,13 +112,14 @@ public class AdminLostItemService {
     @Transactional
     public UpdateLostItemResult updateLostItemTx(Long lostItemId,
                                                  UpdateLostItemCommand command,
-                                                 List<Long> keepImageIds,
                                                  List<UploadedImageData> uploadedImages) {
 
         LostItem lostItem = findPendingLostItem(lostItemId);
 
         List<LostItemImage> existingImages =
                 lostItemImageRepository.findByLostItemId(lostItemId);
+
+        List<Long> keepImageIds = command.keepImageIds();
 
         validateImageOwnershipInMemory(existingImages, keepImageIds);
 
@@ -138,12 +138,18 @@ public class AdminLostItemService {
         return UpdateLostItemResult.from(lostItemId);
     }
 
-
-    private void validateImageOwnershipInMemory(List<LostItemImage> existingImages, List<Long> keepImageIds) {
+    private void validateImageOwnershipInMemory(
+            List<LostItemImage> existingImages,
+            List<Long> keepImageIds
+    ) {
         if (keepImageIds == null || keepImageIds.isEmpty()) {
             return;
         }
-        List<Long> existingIds = existingImages.stream().map(LostItemImage::getId).toList();
+
+        Set<Long> existingIds = existingImages.stream()
+                .map(LostItemImage::getId)
+                .collect(Collectors.toSet());
+
         if (!existingIds.containsAll(keepImageIds)) {
             throw new ApplicationException(LostItemException.INVALID_IMAGE_ACCESS);
         }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/AdminLostItemService.java
@@ -96,28 +96,69 @@ public class AdminLostItemService {
     }
 
     @Transactional
-    public void updateLostItem(Long lostItemId, UpdateLostItemRequest request, List<MultipartFile> images) {
+    public void updateLostItem(Long lostItemId,
+                               UpdateLostItemRequest request,
+                               List<Long> keepImageIds,
+                               List<MultipartFile> newImages) {
 
         LostItem lostItem = adminLostItemRepository.findById(lostItemId)
                 .orElseThrow(() -> new ApplicationException(LostItemException.LOST_ITEM_NOT_FOUND));
 
-        CreateLostItemCommand dummyCommand = CreateLostItemCommand.of(
-                new LostItemRegisterRequest(request.description(), request.depositArea(),
-                        request.foundAreaId(), request.foundAreaDetail(),
-                        request.categoryId(), request.featureOptions()),
-                Collections.emptyList()
-        );
-        LostItemRegisterData validData = lostItemStorageService.getValidRegisterData(dummyCommand);
-
-        List<String> oldImageUrls = lostItemImageRepository.findImageKeysByLostItemIds(List.of(lostItemId));
-        List<UploadedImageData> newUploadedImages = Collections.emptyList();
-
-        if (images != null && !images.isEmpty()) {
-            newUploadedImages = uploadNewImages(images);
-            updateImages(lostItem, newUploadedImages);
+        if (lostItem.getStatus() != LostItemStatus.PENDING) {
+            throw new ApplicationException(LostItemException.ACCESS_FORBIDDEN);
         }
 
+        CreateLostItemCommand dummyCommand = CreateLostItemCommand.of(
+                new LostItemRegisterRequest(
+                        request.description(),
+                        request.depositArea(),
+                        request.foundAreaId(),
+                        request.foundAreaDetail(),
+                        request.categoryId(),
+                        request.featureOptions()
+                ),
+                Collections.emptyList()
+        );
+
+        LostItemRegisterData validData =
+                lostItemStorageService.getValidRegisterData(dummyCommand);
+
+        List<LostItemImage> existingImages =
+                lostItemImageRepository.findByLostItemId(lostItemId);
+
+        List<Long> safeKeepIds = (keepImageIds == null) ? List.of() : keepImageIds;
+
+        if (!safeKeepIds.isEmpty()) {
+            long count = lostItemImageRepository
+                    .countByIdInAndLostItemId(safeKeepIds, lostItemId);
+            if (count != safeKeepIds.size()) {
+                throw new ApplicationException(LostItemException.INVALID_IMAGE_ACCESS);
+            }
+        }
+
+        List<LostItemImage> toDelete = existingImages.stream()
+                .filter(img -> !safeKeepIds.contains(img.getId()))
+                .toList();
+
+        List<UploadedImageData> uploadedNewImages = List.of();
+
         try {
+            if (!toDelete.isEmpty()) {
+                lostItemImageRepository.deleteAll(toDelete);
+                s3FileCleanupService.cleanupOrphanFiles(
+                        toDelete.stream().map(LostItemImage::getImageKey).toList()
+                );
+            }
+
+            if (newImages != null && !newImages.isEmpty()) {
+                uploadedNewImages = uploadNewImages(newImages);
+                lostItemImageRepository.saveAll(
+                        uploadedNewImages.stream()
+                                .map(data -> LostItemImage.of(lostItem, data.url(), data.order()))
+                                .toList()
+                );
+            }
+
             lostItem.updateInfo(
                     request.description(),
                     request.depositArea(),
@@ -127,16 +168,14 @@ public class AdminLostItemService {
             );
 
             updateFeatures(lostItem, validData);
+
             lostItem.approve();
 
-            if (!newUploadedImages.isEmpty()) {
-                s3FileCleanupService.cleanupOrphanFiles(oldImageUrls);
-            }
-
         } catch (Exception e) {
-            if (!newUploadedImages.isEmpty()) {
-                List<String> currentUploadedUrls = newUploadedImages.stream().map(UploadedImageData::url).toList();
-                s3FileCleanupService.cleanupOrphanFiles(currentUploadedUrls);
+            if (!uploadedNewImages.isEmpty()) {
+                s3FileCleanupService.cleanupOrphanFiles(
+                        uploadedNewImages.stream().map(UploadedImageData::url).toList()
+                );
             }
             throw e;
         }
@@ -148,14 +187,6 @@ public class AdminLostItemService {
                 .map(img -> new UploadedImageData(s3ImageFileManager.upload(img.imageFile(), IMAGE_DIRECTORY),
                         img.order()))
                 .toList();
-    }
-
-    private void updateImages(LostItem lostItem, List<UploadedImageData> uploadedImages) {
-        lostItemImageRepository.deleteByLostItemIds(List.of(lostItem.getId()));
-        List<LostItemImage> newImageEntities = uploadedImages.stream()
-                .map(data -> LostItemImage.of(lostItem, data.url(), data.order()))
-                .toList();
-        lostItemImageRepository.saveAll(newImageEntities);
     }
 
     private void updateFeatures(LostItem lostItem, LostItemRegisterData validData) {

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/dto/AdminLostItemResult.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/dto/AdminLostItemResult.java
@@ -1,6 +1,8 @@
 package com.greedy.zupzup.admin.lostitem.application.dto;
 
+import com.greedy.zupzup.lostitem.domain.LostItem;
 import java.util.List;
+import java.util.Map;
 
 public record AdminLostItemResult(
         Long id,
@@ -15,20 +17,38 @@ public record AdminLostItemResult(
         List<String> imageUrl,
         List<AdminFeatureOptionDto> featureOptions
 ) {
-    public static AdminLostItemResult from(AdminLostItemResult c, List<AdminFeatureOptionDto> featureOptions) {
+    public static AdminLostItemResult from(
+            LostItem item,
+            List<String> imageUrls,
+            List<AdminFeatureOptionDto> featureOptions
+    ) {
 
         return new AdminLostItemResult(
-                c.id(),
-                c.categoryId(),
-                c.categoryName(),
-                c.schoolAreaId(),
-                c.schoolAreaName(),
-                c.foundAreaDetail,
-                c.createdAt(),
-                c.description(),
-                c.depositArea(),
-                c.imageUrl,
+                item.getId(),
+                item.getCategory().getId(),
+                item.getCategory().getName(),
+                item.getFoundArea().getId(),
+                item.getFoundArea().getAreaName(),
+                item.getFoundAreaDetail(),
+                item.getCreatedAt().toString(),
+                item.getDescription(),
+                item.getDepositArea(),
+                imageUrls,
                 featureOptions
         );
+    }
+
+    public static List<AdminLostItemResult> fromList(
+            List<LostItem> items,
+            Map<Long, List<String>> imageMap,
+            Map<Long, List<AdminFeatureOptionDto>> featureMap
+    ) {
+        return items.stream()
+                .map(item -> from(
+                        item,
+                        imageMap.getOrDefault(item.getId(), List.of()),
+                        featureMap.getOrDefault(item.getId(), List.of())
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/dto/UpdateLostItemCommand.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/dto/UpdateLostItemCommand.java
@@ -2,30 +2,19 @@ package com.greedy.zupzup.admin.lostitem.application.dto;
 
 import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
 import com.greedy.zupzup.lostitem.presentation.dto.ItemFeatureRequest;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public record UpdateLostItemCommand(
-        @NotNull(message = "분실물 ID는 필수입니다.")
         Long lostItemId,
-        @NotBlank(message = "설명은 비어 있을 수 없습니다.")
         String description,
-        @NotBlank(message = "보관 장소를 입력해 주세요.")
         String depositArea,
-        @NotNull(message = "습득 구역 ID는 필수입니다.")
         Long foundAreaId,
-        @NotBlank(message = "상세 습득 장소를 입력해 주세요.")
         String foundAreaDetail,
-        @NotNull(message = "카테고리 ID는 필수입니다.")
         Long categoryId,
-        @Valid @NotNull(message = "특징 옵션 목록은 필수입니다.")
         List<ItemFeatureRequest> featureOptions,
         List<Long> keepImageIds,
         List<MultipartFile> newImages
-
 ) {
     public static UpdateLostItemCommand of(Long lostItemId, UpdateLostItemRequest request,
                                            List<MultipartFile> newImages) {

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/dto/UpdateLostItemCommand.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/dto/UpdateLostItemCommand.java
@@ -1,5 +1,6 @@
-package com.greedy.zupzup.admin.lostitem.presentation.dto;
+package com.greedy.zupzup.admin.lostitem.application.dto;
 
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
 import com.greedy.zupzup.lostitem.presentation.dto.ItemFeatureRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/application/dto/UpdateLostItemResult.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/application/dto/UpdateLostItemResult.java
@@ -1,0 +1,13 @@
+package com.greedy.zupzup.admin.lostitem.application.dto;
+
+public record UpdateLostItemResult(
+        Long lostItemId,
+        String message
+) {
+    public static UpdateLostItemResult from(Long id) {
+        return new UpdateLostItemResult(
+                id,
+                "분실물 정보가 성공적으로 수정 및 승인되었습니다."
+        );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
@@ -1,75 +1,87 @@
-package com.greedy.zupzup.admin.lostitem.presentation;
+    package com.greedy.zupzup.admin.lostitem.presentation;
 
-import com.greedy.zupzup.admin.lostitem.application.AdminLostItemService;
-import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemResult;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminPendingLostItemListResponse;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemResponse;
-import com.greedy.zupzup.lostitem.presentation.dto.LostItemListRequest;
-import jakarta.validation.Valid;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
+    import com.fasterxml.jackson.core.type.TypeReference;
+    import com.fasterxml.jackson.databind.ObjectMapper;
+    import com.greedy.zupzup.admin.lostitem.application.AdminLostItemService;
+    import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemResult;
+    import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminPendingLostItemListResponse;
+    import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest;
+    import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
+    import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
+    import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
+    import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
+    import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
+    import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemResponse;
+    import com.greedy.zupzup.lostitem.presentation.dto.LostItemListRequest;
+    import jakarta.validation.Valid;
+    import java.util.Collections;
+    import java.util.List;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.http.MediaType;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.web.bind.annotation.GetMapping;
+    import org.springframework.web.bind.annotation.PathVariable;
+    import org.springframework.web.bind.annotation.PostMapping;
+    import org.springframework.web.bind.annotation.PutMapping;
+    import org.springframework.web.bind.annotation.RequestMapping;
+    import org.springframework.web.bind.annotation.RequestBody;
+    import org.springframework.web.bind.annotation.RequestPart;
+    import org.springframework.web.bind.annotation.RestController;
+    import org.springframework.web.multipart.MultipartFile;
 
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/api/admin/lost-items")
-public class AdminLostItemController implements AdminLostItemControllerDocs{
+    @RestController
+    @RequiredArgsConstructor
+    @RequestMapping("/api/admin/lost-items")
+    public class AdminLostItemController implements AdminLostItemControllerDocs{
 
-    private final AdminLostItemService adminLostItemService;
+        private final AdminLostItemService adminLostItemService;
 
-    @PostMapping("/approve")
-    public ResponseEntity<ApproveLostItemsResponse> approveBulk(
-            @Valid @RequestBody ApproveLostItemsRequest request) {
-        ApproveLostItemsResponse result = adminLostItemService.approveBulk(request);
-        return ResponseEntity.ok(result);
+        @PostMapping("/approve")
+        public ResponseEntity<ApproveLostItemsResponse> approveBulk(
+                @Valid @RequestBody ApproveLostItemsRequest request) {
+            ApproveLostItemsResponse result = adminLostItemService.approveBulk(request);
+            return ResponseEntity.ok(result);
+        }
+
+        @PostMapping("/reject")
+        public ResponseEntity<RejectLostItemsResponse> rejectBulk(
+                @Valid @RequestBody RejectLostItemsRequest request) {
+            RejectLostItemsResponse result = adminLostItemService.rejectBulk(request);
+            return ResponseEntity.ok(result);
+        }
+
+        @GetMapping("/pending")
+        public ResponseEntity<AdminPendingLostItemListResponse> listPending(
+                @Valid LostItemListRequest query) {
+            AdminPendingLostItemListResponse response =
+                    adminLostItemService.getPendingLostItems(query.safePage(), query.safeLimit());
+
+            return ResponseEntity.ok(response);
+        }
+
+        @Override
+        @PutMapping(value = "/{lostItemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<UpdateLostItemResponse> updateLostItem(
+                @PathVariable Long lostItemId,
+
+                @RequestPart(value = "newImages", required = false)
+                List<MultipartFile> newImages,
+
+                @RequestPart("updateRequest")
+                @Valid UpdateLostItemRequest updateRequest
+        ) {
+
+            UpdateLostItemCommand command = UpdateLostItemCommand.of(updateRequest);
+
+            UpdateLostItemResult result = adminLostItemService.updateLostItem(
+                    lostItemId,
+                    command,
+                    newImages
+            );
+
+            return ResponseEntity.ok(
+                    UpdateLostItemResponse.from(result.lostItemId())
+            );
+
+        }
     }
-
-    @PostMapping("/reject")
-    public ResponseEntity<RejectLostItemsResponse> rejectBulk(
-            @Valid @RequestBody RejectLostItemsRequest request) {
-        RejectLostItemsResponse result = adminLostItemService.rejectBulk(request);
-        return ResponseEntity.ok(result);
-    }
-
-    @GetMapping("/pending")
-    public ResponseEntity<AdminPendingLostItemListResponse> listPending(
-            @Valid LostItemListRequest query) {
-        AdminPendingLostItemListResponse response =
-                adminLostItemService.getPendingLostItems(query.safePage(), query.safeLimit());
-
-        return ResponseEntity.ok(response);
-    }
-
-    @Override
-    @PutMapping(value = "/{lostItemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<UpdateLostItemResponse> updateLostItem(
-            @PathVariable Long lostItemId,
-            @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
-            @RequestPart(value = "keepImageIds", required = false) List<Long> keepImageIds,
-            @RequestPart(value = "updateRequest") @Valid UpdateLostItemRequest updateRequest
-    ) {
-        UpdateLostItemCommand command = UpdateLostItemCommand.of(updateRequest);
-
-        UpdateLostItemResult result = adminLostItemService.updateLostItem(
-                lostItemId, command, keepImageIds, newImages
-        );
-
-        return ResponseEntity.ok(UpdateLostItemResponse.from(result.lostItemId()));
-    }
-}

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
@@ -6,15 +6,23 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemResponse;
 import com.greedy.zupzup.lostitem.presentation.dto.LostItemListRequest;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,5 +52,15 @@ public class AdminLostItemController {
                 adminLostItemService.getPendingLostItems(query.safePage(), query.safeLimit());
 
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping(value = "/{lostItemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UpdateLostItemResponse> updateLostItem(
+            @PathVariable Long lostItemId,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @Valid @RequestPart("updateRequest") UpdateLostItemRequest updateRequest) {
+
+        adminLostItemService.updateLostItem(lostItemId, updateRequest, images);
+        return ResponseEntity.ok(UpdateLostItemResponse.from(lostItemId));
     }
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
@@ -1,7 +1,5 @@
     package com.greedy.zupzup.admin.lostitem.presentation;
 
-    import com.fasterxml.jackson.core.type.TypeReference;
-    import com.fasterxml.jackson.databind.ObjectMapper;
     import com.greedy.zupzup.admin.lostitem.application.AdminLostItemService;
     import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemResult;
     import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminPendingLostItemListResponse;
@@ -14,7 +12,6 @@
     import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemResponse;
     import com.greedy.zupzup.lostitem.presentation.dto.LostItemListRequest;
     import jakarta.validation.Valid;
-    import java.util.Collections;
     import java.util.List;
     import lombok.RequiredArgsConstructor;
     import org.springframework.http.MediaType;
@@ -59,29 +56,14 @@
             return ResponseEntity.ok(response);
         }
 
-        @Override
         @PutMapping(value = "/{lostItemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
         public ResponseEntity<UpdateLostItemResponse> updateLostItem(
                 @PathVariable Long lostItemId,
-
-                @RequestPart(value = "newImages", required = false)
-                List<MultipartFile> newImages,
-
-                @RequestPart("updateRequest")
-                @Valid UpdateLostItemRequest updateRequest
+                @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
+                @RequestPart("updateRequest") @Valid UpdateLostItemRequest updateRequest
         ) {
-
-            UpdateLostItemCommand command = UpdateLostItemCommand.of(updateRequest);
-
-            UpdateLostItemResult result = adminLostItemService.updateLostItem(
-                    lostItemId,
-                    command,
-                    newImages
-            );
-
-            return ResponseEntity.ok(
-                    UpdateLostItemResponse.from(result.lostItemId())
-            );
-
+            UpdateLostItemCommand command = UpdateLostItemCommand.of(lostItemId, updateRequest, newImages);
+            UpdateLostItemResult result = adminLostItemService.updateLostItem(command);
+            return ResponseEntity.ok(UpdateLostItemResponse.from(result.lostItemId()));
         }
     }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
@@ -1,5 +1,6 @@
 package com.greedy.zupzup.admin.lostitem.presentation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.greedy.zupzup.admin.lostitem.application.AdminLostItemService;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminPendingLostItemListResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest;
@@ -30,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class AdminLostItemController {
 
     private final AdminLostItemService adminLostItemService;
+    private final ObjectMapper objectMapper;
 
     @PostMapping("/approve")
     public ResponseEntity<ApproveLostItemsResponse> approveBulk(
@@ -58,16 +60,10 @@ public class AdminLostItemController {
     public ResponseEntity<UpdateLostItemResponse> updateLostItem(
             @PathVariable Long lostItemId,
             @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
-            @RequestPart("keepImageIds") List<Long> keepImageIds,
-            @RequestPart("updateRequest") UpdateLostItemRequest updateRequest
+            @RequestPart(value = "keepImageIds", required = false) List<Long> keepImageIds,
+            @RequestPart(value = "updateRequest") @Valid UpdateLostItemRequest updateRequest
     ) {
-        adminLostItemService.updateLostItem(
-                lostItemId,
-                updateRequest,
-                keepImageIds,
-                newImages
-        );
+        adminLostItemService.updateLostItem(lostItemId, updateRequest, keepImageIds, newImages);
         return ResponseEntity.ok(UpdateLostItemResponse.from(lostItemId));
     }
-
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
@@ -28,7 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/lost-items")
-public class AdminLostItemController {
+public class AdminLostItemController implements AdminLostItemControllerDocs{
 
     private final AdminLostItemService adminLostItemService;
     private final ObjectMapper objectMapper;

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
@@ -7,7 +7,7 @@
     import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
     import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
     import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
-    import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
+    import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemCommand;
     import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
     import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemResponse;
     import com.greedy.zupzup.lostitem.presentation.dto.LostItemListRequest;

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
@@ -1,12 +1,13 @@
 package com.greedy.zupzup.admin.lostitem.presentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.greedy.zupzup.admin.lostitem.application.AdminLostItemService;
+import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemResult;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminPendingLostItemListResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemResponse;
 import com.greedy.zupzup.lostitem.presentation.dto.LostItemListRequest;
@@ -31,7 +32,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class AdminLostItemController implements AdminLostItemControllerDocs{
 
     private final AdminLostItemService adminLostItemService;
-    private final ObjectMapper objectMapper;
 
     @PostMapping("/approve")
     public ResponseEntity<ApproveLostItemsResponse> approveBulk(
@@ -56,6 +56,7 @@ public class AdminLostItemController implements AdminLostItemControllerDocs{
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @PutMapping(value = "/{lostItemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UpdateLostItemResponse> updateLostItem(
             @PathVariable Long lostItemId,
@@ -63,7 +64,12 @@ public class AdminLostItemController implements AdminLostItemControllerDocs{
             @RequestPart(value = "keepImageIds", required = false) List<Long> keepImageIds,
             @RequestPart(value = "updateRequest") @Valid UpdateLostItemRequest updateRequest
     ) {
-        adminLostItemService.updateLostItem(lostItemId, updateRequest, keepImageIds, newImages);
-        return ResponseEntity.ok(UpdateLostItemResponse.from(lostItemId));
+        UpdateLostItemCommand command = UpdateLostItemCommand.of(updateRequest);
+
+        UpdateLostItemResult result = adminLostItemService.updateLostItem(
+                lostItemId, command, keepImageIds, newImages
+        );
+
+        return ResponseEntity.ok(UpdateLostItemResponse.from(result.lostItemId()));
     }
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemController.java
@@ -57,10 +57,17 @@ public class AdminLostItemController {
     @PutMapping(value = "/{lostItemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UpdateLostItemResponse> updateLostItem(
             @PathVariable Long lostItemId,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
-            @Valid @RequestPart("updateRequest") UpdateLostItemRequest updateRequest) {
-
-        adminLostItemService.updateLostItem(lostItemId, updateRequest, images);
+            @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
+            @RequestPart("keepImageIds") List<Long> keepImageIds,
+            @RequestPart("updateRequest") UpdateLostItemRequest updateRequest
+    ) {
+        adminLostItemService.updateLostItem(
+                lostItemId,
+                updateRequest,
+                keepImageIds,
+                newImages
+        );
         return ResponseEntity.ok(UpdateLostItemResponse.from(lostItemId));
     }
+
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemControllerDocs.java
@@ -11,6 +11,7 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemResponse;
 import com.greedy.zupzup.global.exception.ErrorResponse;
 import com.greedy.zupzup.lostitem.presentation.dto.LostItemListRequest;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,6 +23,8 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Admin - LostItem", description = "관리자 분실물 승인/거절/조회 API")
@@ -187,13 +190,7 @@ public interface AdminLostItemControllerDocs {
     );
 
     @Operation(
-            summary = "보류 분실물 상세 정보 수정 및 승인",
-            description = """
-                    관리자 권한으로 보류(PENDING) 상태인 분실물의 정보를 수정하고 즉시 승인(REGISTERED) 처리합니다.
-                    - 사진 수정: 유지할 이미지 ID 목록(`keepImageIds`)과 새 이미지 파일(`newImages`)을 함께 보냅니다.
-                    - 사진을 변경하지 않을 경우: 기존 이미지 ID들을 `keepImageIds`에 모두 담고, `newImages`는 비워서 보냅니다.
-                    - 정보 수정: 카테고리, 특징 옵션, 설명 등을 `updateRequest`에 담아 보냅니다.
-                    """
+            summary = "보류 분실물 상세 정보 수정 및 승인"
     )
     @ApiResponses({
             @ApiResponse(
@@ -203,49 +200,47 @@ public interface AdminLostItemControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청 (이미지 개수 부족, 필수 특징값 누락 등)",
+                    description = "잘못된 요청",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "403",
-                    description = "권한 없음 또는 이미 승인된 물건 수정 시도",
+                    description = "권한 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "존재하지 않는 분실물 ID",
+                    description = "존재하지 않는 분실물",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-
     ResponseEntity<UpdateLostItemResponse> updateLostItem(
-            @Schema(description = "수정할 분실물 ID", example = "1")
-            Long lostItemId,
+            @Parameter(description = "분실물 ID", example = "1")
+            @PathVariable Long lostItemId,
 
-            @Schema(description = "새로 업로드할 이미지 파일 리스트")
+            @RequestPart(value = "newImages", required = false)
+            @Schema(description = "새 이미지 파일 리스트")
             List<MultipartFile> newImages,
 
-            @Schema(description = "유지할 기존 이미지 ID 리스트", example = "[1, 2]")
-            List<Long> keepImageIds,
-
+            @RequestPart("updateRequest")
             @Valid
-            @RequestBody(
-                    description = "수정할 텍스트 정보 및 특징 옵션",
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "수정 JSON (keepImageIds 포함)",
                     content = @Content(
-                            mediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = UpdateLostItemRequest.class),
+                            mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
                                             {
-                                              "description": "수정된 상세 설명입니다.",
-                                              "depositArea": "학생회관 2층",
-                                              "foundAreaId": 1,
-                                              "foundAreaDetail": "대양 AI센터 B2층",
-                                              "categoryId": 1,
+                                              "description": "수정된 설명",
+                                              "depositArea": "학생회관",
+                                              "schoolAreaId": 1,
+                                              "foundAreaDetail": "1층",
+                                              "categoryId": 10,
                                               "featureOptions": [
                                                 { "featureId": 1, "optionId": 1 },
                                                 { "featureId": 2, "optionId": 5 }
-                                              ]
+                                              ],
+                                              "keepImageIds": [10, 11]
                                             }
                                             """
                             )

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemControllerDocs.java
@@ -190,13 +190,32 @@ public interface AdminLostItemControllerDocs {
     );
 
     @Operation(
-            summary = "보류 분실물 상세 정보 수정 및 승인"
+            summary = "보류 분실물 상세 정보 수정 및 승인",
+            description = """
+                    보류 상태의 분실물 정보를 수정하고, 정상 처리 시 상태를 REGISTERED로 변경합니다.
+                    - newImages: 새로 추가할 이미지 파일 리스트(선택)
+                    - updateRequest: 수정할 JSON 데이터(필수)
+                    """,
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(mediaType = "multipart/form-data")
+            )
     )
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
                     description = "수정 및 승인 성공",
-                    content = @Content(schema = @Schema(implementation = UpdateLostItemResponse.class))
+                    content = @Content(
+                            schema = @Schema(implementation = UpdateLostItemResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "lostItemId": 1,
+                                              "message": "분실물 정보가 성공적으로 수정 및 승인되었습니다."
+                                            }
+                                            """
+                            )
+                    )
             ),
             @ApiResponse(
                     responseCode = "400",
@@ -218,22 +237,27 @@ public interface AdminLostItemControllerDocs {
             @Parameter(description = "분실물 ID", example = "1")
             @PathVariable Long lostItemId,
 
+            @Parameter(
+                    description = "새 이미지 파일 리스트(선택). multipart/form-data의 newImages 파트로 전송합니다.",
+                    content = @Content(
+                            mediaType = "multipart/form-data",
+                            schema = @Schema(type = "string", format = "binary")
+                    )
+            )
             @RequestPart(value = "newImages", required = false)
-            @Schema(description = "새 이미지 파일 리스트")
             List<MultipartFile> newImages,
 
-            @RequestPart("updateRequest")
-            @Valid
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "수정 JSON (keepImageIds 포함)",
+            @Parameter(
+                    description = "수정 JSON (keepImageIds 포함). multipart/form-data의 updateRequest 파트로 전송합니다.",
                     content = @Content(
                             mediaType = "application/json",
+                            schema = @Schema(implementation = UpdateLostItemRequest.class),
                             examples = @ExampleObject(
                                     value = """
                                             {
                                               "description": "수정된 설명",
                                               "depositArea": "학생회관",
-                                              "schoolAreaId": 1,
+                                              "foundAreaId": 1,
                                               "foundAreaDetail": "1층",
                                               "categoryId": 10,
                                               "featureOptions": [
@@ -246,6 +270,9 @@ public interface AdminLostItemControllerDocs {
                             )
                     )
             )
+            @RequestPart("updateRequest")
+            @Valid
             UpdateLostItemRequest updateRequest
     );
+
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemControllerDocs.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/AdminLostItemControllerDocs.java
@@ -6,18 +6,23 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemResponse;
 import com.greedy.zupzup.global.exception.ErrorResponse;
 import com.greedy.zupzup.lostitem.presentation.dto.LostItemListRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Admin - LostItem", description = "관리자 분실물 승인/거절/조회 API")
 public interface AdminLostItemControllerDocs {
@@ -179,5 +184,73 @@ public interface AdminLostItemControllerDocs {
     })
     ResponseEntity<AdminPendingLostItemListResponse> listPending(
             @ParameterObject @Valid LostItemListRequest query
+    );
+
+    @Operation(
+            summary = "보류 분실물 상세 정보 수정 및 승인",
+            description = """
+                    관리자 권한으로 보류(PENDING) 상태인 분실물의 정보를 수정하고 즉시 승인(REGISTERED) 처리합니다.
+                    - 사진 수정: 유지할 이미지 ID 목록(`keepImageIds`)과 새 이미지 파일(`newImages`)을 함께 보냅니다.
+                    - 사진을 변경하지 않을 경우: 기존 이미지 ID들을 `keepImageIds`에 모두 담고, `newImages`는 비워서 보냅니다.
+                    - 정보 수정: 카테고리, 특징 옵션, 설명 등을 `updateRequest`에 담아 보냅니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 및 승인 성공",
+                    content = @Content(schema = @Schema(implementation = UpdateLostItemResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (이미지 개수 부족, 필수 특징값 누락 등)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 또는 이미 승인된 물건 수정 시도",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 분실물 ID",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+
+    ResponseEntity<UpdateLostItemResponse> updateLostItem(
+            @Schema(description = "수정할 분실물 ID", example = "1")
+            Long lostItemId,
+
+            @Schema(description = "새로 업로드할 이미지 파일 리스트")
+            List<MultipartFile> newImages,
+
+            @Schema(description = "유지할 기존 이미지 ID 리스트", example = "[1, 2]")
+            List<Long> keepImageIds,
+
+            @Valid
+            @RequestBody(
+                    description = "수정할 텍스트 정보 및 특징 옵션",
+                    content = @Content(
+                            mediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = UpdateLostItemRequest.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "description": "수정된 상세 설명입니다.",
+                                              "depositArea": "학생회관 2층",
+                                              "foundAreaId": 1,
+                                              "foundAreaDetail": "대양 AI센터 B2층",
+                                              "categoryId": 1,
+                                              "featureOptions": [
+                                                { "featureId": 1, "optionId": 1 },
+                                                { "featureId": 2, "optionId": 5 }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            )
+            UpdateLostItemRequest updateRequest
     );
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/AdminLostItemDto.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/AdminLostItemDto.java
@@ -1,10 +1,10 @@
-package com.greedy.zupzup.admin.lostitem.application.dto;
+package com.greedy.zupzup.admin.lostitem.presentation.dto;
 
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import java.util.List;
 import java.util.Map;
 
-public record AdminLostItemResult(
+public record AdminLostItemDto(
         Long id,
         Long categoryId,
         String categoryName,
@@ -15,15 +15,15 @@ public record AdminLostItemResult(
         String description,
         String depositArea,
         List<String> imageUrl,
-        List<AdminFeatureOptionDto> featureOptions
+        List<LostItemFeatureOptionDto> featureOptions
 ) {
-    public static AdminLostItemResult from(
+    public static AdminLostItemDto from(
             LostItem item,
             List<String> imageUrls,
-            List<AdminFeatureOptionDto> featureOptions
+            List<LostItemFeatureOptionDto> featureOptions
     ) {
 
-        return new AdminLostItemResult(
+        return new AdminLostItemDto(
                 item.getId(),
                 item.getCategory().getId(),
                 item.getCategory().getName(),
@@ -38,10 +38,10 @@ public record AdminLostItemResult(
         );
     }
 
-    public static List<AdminLostItemResult> fromList(
+    public static List<AdminLostItemDto> fromList(
             List<LostItem> items,
             Map<Long, List<String>> imageMap,
-            Map<Long, List<AdminFeatureOptionDto>> featureMap
+            Map<Long, List<LostItemFeatureOptionDto>> featureMap
     ) {
         return items.stream()
                 .map(item -> from(

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/AdminPendingLostItemListResponse.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/AdminPendingLostItemListResponse.java
@@ -1,18 +1,16 @@
 package com.greedy.zupzup.admin.lostitem.presentation.dto;
 
-import com.greedy.zupzup.admin.lostitem.application.dto.AdminLostItemResult;
-
 import com.greedy.zupzup.lostitem.presentation.dto.PageInfoResponse;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
 public record AdminPendingLostItemListResponse(
         int count,
-        List<AdminLostItemResult> items,
+        List<AdminLostItemDto> items,
         PageInfoResponse pageInfo
 ) {
-    public static AdminPendingLostItemListResponse of(Page<AdminLostItemResult> pageResult) {
-        List<AdminLostItemResult> items = pageResult.getContent();
+    public static AdminPendingLostItemListResponse of(Page<AdminLostItemDto> pageResult) {
+        List<AdminLostItemDto> items = pageResult.getContent();
 
         return new AdminPendingLostItemListResponse(
                 items.size(),
@@ -22,7 +20,7 @@ public record AdminPendingLostItemListResponse(
     }
 
     public static AdminPendingLostItemListResponse of(
-            List<AdminLostItemResult> commands,
+            List<AdminLostItemDto> commands,
             int page,
             int limit,
             long totalCount

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/LostItemFeatureOptionDto.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/LostItemFeatureOptionDto.java
@@ -1,16 +1,16 @@
-package com.greedy.zupzup.admin.lostitem.application.dto;
+package com.greedy.zupzup.admin.lostitem.presentation.dto;
 
 import com.greedy.zupzup.category.domain.FeatureOption;
 import lombok.Builder;
 
 @Builder
-public record AdminFeatureOptionDto(
+public record LostItemFeatureOptionDto(
         Long id,
         String optionValue,
         String quizQuestion
 ) {
-    public static AdminFeatureOptionDto of(FeatureOption option) {
-        return new AdminFeatureOptionDto(
+    public static LostItemFeatureOptionDto of(FeatureOption option) {
+        return new LostItemFeatureOptionDto(
                 option.getId(),
                 option.getOptionValue(),
                 option.getFeature().getQuizQuestion()

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemCommand.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemCommand.java
@@ -5,8 +5,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public record UpdateLostItemCommand(
+        @NotNull(message = "분실물 ID는 필수입니다.")
+        Long lostItemId,
         @NotBlank(message = "설명은 비어 있을 수 없습니다.")
         String description,
         @NotBlank(message = "보관 장소를 입력해 주세요.")
@@ -19,18 +22,22 @@ public record UpdateLostItemCommand(
         Long categoryId,
         @Valid @NotNull(message = "특징 옵션 목록은 필수입니다.")
         List<ItemFeatureRequest> featureOptions,
-        List<Long> keepImageIds
+        List<Long> keepImageIds,
+        List<MultipartFile> newImages
 
 ) {
-    public static UpdateLostItemCommand of(UpdateLostItemRequest request) {
+    public static UpdateLostItemCommand of(Long lostItemId, UpdateLostItemRequest request,
+                                           List<MultipartFile> newImages) {
         return new UpdateLostItemCommand(
+                lostItemId,
                 request.description(),
                 request.depositArea(),
                 request.foundAreaId(),
                 request.foundAreaDetail(),
                 request.categoryId(),
                 request.featureOptions(),
-                request.keepImageIds() == null ? List.of() : request.keepImageIds()
+                request.keepImageIds() == null ? List.of() : request.keepImageIds(),
+                newImages == null ? List.of() : newImages
         );
     }
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemCommand.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemCommand.java
@@ -18,7 +18,9 @@ public record UpdateLostItemCommand(
         @NotNull(message = "카테고리 ID는 필수입니다.")
         Long categoryId,
         @Valid @NotNull(message = "특징 옵션 목록은 필수입니다.")
-        List<ItemFeatureRequest> featureOptions
+        List<ItemFeatureRequest> featureOptions,
+        List<Long> keepImageIds
+
 ) {
     public static UpdateLostItemCommand of(UpdateLostItemRequest request) {
         return new UpdateLostItemCommand(
@@ -27,7 +29,8 @@ public record UpdateLostItemCommand(
                 request.foundAreaId(),
                 request.foundAreaDetail(),
                 request.categoryId(),
-                request.featureOptions()
+                request.featureOptions(),
+                request.keepImageIds() == null ? List.of() : request.keepImageIds()
         );
     }
 }

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemCommand.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemCommand.java
@@ -1,0 +1,33 @@
+package com.greedy.zupzup.admin.lostitem.presentation.dto;
+
+import com.greedy.zupzup.lostitem.presentation.dto.ItemFeatureRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record UpdateLostItemCommand(
+        @NotBlank(message = "설명은 비어 있을 수 없습니다.")
+        String description,
+        @NotBlank(message = "보관 장소를 입력해 주세요.")
+        String depositArea,
+        @NotNull(message = "습득 구역 ID는 필수입니다.")
+        Long foundAreaId,
+        @NotBlank(message = "상세 습득 장소를 입력해 주세요.")
+        String foundAreaDetail,
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        Long categoryId,
+        @Valid @NotNull(message = "특징 옵션 목록은 필수입니다.")
+        List<ItemFeatureRequest> featureOptions
+) {
+    public static UpdateLostItemCommand of(UpdateLostItemRequest request) {
+        return new UpdateLostItemCommand(
+                request.description(),
+                request.depositArea(),
+                request.foundAreaId(),
+                request.foundAreaDetail(),
+                request.categoryId(),
+                request.featureOptions()
+        );
+    }
+}

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemRequest.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemRequest.java
@@ -1,0 +1,28 @@
+package com.greedy.zupzup.admin.lostitem.presentation.dto;
+
+import com.greedy.zupzup.lostitem.presentation.dto.ItemFeatureRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record UpdateLostItemRequest(
+        @NotBlank(message = "설명은 비어 있을 수 없습니다.")
+        String description,
+
+        @NotBlank(message = "보관 장소를 입력해 주세요.")
+        String depositArea,
+
+        @NotNull(message = "습득 구역 ID는 필수입니다.")
+        Long foundAreaId,
+
+        @NotBlank(message = "상세 습득 장소를 입력해 주세요.")
+        String foundAreaDetail,
+
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        Long categoryId,
+
+        @Valid
+        @NotNull(message = "특징 옵션 목록은 필수입니다.")
+        List<ItemFeatureRequest> featureOptions
+) {}

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemRequest.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemRequest.java
@@ -24,5 +24,8 @@ public record UpdateLostItemRequest(
 
         @Valid
         @NotNull(message = "특징 옵션 목록은 필수입니다.")
-        List<ItemFeatureRequest> featureOptions
-) {}
+        List<ItemFeatureRequest> featureOptions,
+        List<Long> keepImageIds
+
+) {
+}

--- a/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemResponse.java
+++ b/src/main/java/com/greedy/zupzup/admin/lostitem/presentation/dto/UpdateLostItemResponse.java
@@ -1,0 +1,10 @@
+package com.greedy.zupzup.admin.lostitem.presentation.dto;
+
+public record UpdateLostItemResponse(
+        Long lostItemId,
+        String message
+) {
+    public static UpdateLostItemResponse from(Long id) {
+        return new UpdateLostItemResponse(id, "분실물 정보가 성공적으로 수정 및 승인되었습니다.");
+    }
+}

--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemStorageService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemStorageService.java
@@ -1,6 +1,6 @@
 package com.greedy.zupzup.lostitem.application;
 
-import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
+import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemCommand;
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.domain.Feature;
 import com.greedy.zupzup.category.domain.FeatureOption;

--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemStorageService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemStorageService.java
@@ -1,5 +1,6 @@
 package com.greedy.zupzup.lostitem.application;
 
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.domain.Feature;
 import com.greedy.zupzup.category.domain.FeatureOption;
@@ -8,6 +9,8 @@ import com.greedy.zupzup.category.exception.LostItemFeatureException;
 import com.greedy.zupzup.category.repository.CategoryRepository;
 import com.greedy.zupzup.category.repository.FeatureOptionRepository;
 import com.greedy.zupzup.global.exception.ApplicationException;
+import com.greedy.zupzup.global.infrastructure.S3FileCleanupService;
+import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
 import com.greedy.zupzup.lostitem.application.dto.*;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
@@ -18,12 +21,14 @@ import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import com.greedy.zupzup.schoolarea.repository.SchoolAreaRepository;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +40,8 @@ public class LostItemStorageService {
     private final FeatureOptionRepository featureOptionRepository;
     private final SchoolAreaRepository schoolAreaRepository;
     private final CategoryRepository categoryRepository;
-
+    private final S3FileCleanupService s3FileCleanupService;
+    private final S3ImageFileManager s3ImageFileManager;
 
     /**
      * 1. 분실물 등록에 필요한 모든 데이터를 조회하고 유효성을 검사.
@@ -137,4 +143,89 @@ public class LostItemStorageService {
         lostItemFeatureRepository.saveAll(newFeatures);
     }
 
+    @Transactional(readOnly = true)
+    public LostItemRegisterData getValidUpdateData(UpdateLostItemCommand command) {
+
+        Category category = getCategory(command.categoryId());
+        SchoolArea foundSchoolArea = schoolAreaRepository.getAreaById(command.foundAreaId());
+
+        if (category.isEtcCategory() || command.featureOptions() == null) {
+            return new LostItemRegisterData(category, foundSchoolArea, List.of());
+        }
+
+        List<ItemFeatureOptionCommand> featureCommands =
+                command.featureOptions().stream()
+                        .map(opt -> new ItemFeatureOptionCommand(
+                                opt.featureId(),
+                                opt.optionId()
+                        ))
+                        .toList();
+
+        List<Pair<Feature, FeatureOption>> validFeatureAndOptions =
+                getValidFeatureAndOptions(category, featureCommands);
+
+        return new LostItemRegisterData(category, foundSchoolArea, validFeatureAndOptions);
+    }
+
+    @Transactional
+    public void updateLostItem(LostItem lostItem, UpdateLostItemCommand command,
+                               LostItemRegisterData validData, List<Long> keepImageIds,
+                               List<UploadedImageData> uploadedImages, List<LostItemImage> existingImages) {
+
+        List<Long> safeKeepIds = (keepImageIds == null) ? List.of() : keepImageIds;
+        List<LostItemImage> toDelete = existingImages.stream()
+                .filter(img -> !safeKeepIds.contains(img.getId()))
+                .toList();
+
+        if (!toDelete.isEmpty()) {
+            lostItemImageRepository.deleteAll(toDelete);
+            s3FileCleanupService.cleanupOrphanFiles(
+                    toDelete.stream().map(LostItemImage::getImageKey).toList()
+            );
+        }
+
+        if (uploadedImages != null && !uploadedImages.isEmpty()) {
+            List<LostItemImage> newImages = uploadedImages.stream()
+                    .map(data -> LostItemImage.of(lostItem, data.url(), data.order()))
+                    .toList();
+            lostItemImageRepository.saveAll(newImages);
+        }
+
+        lostItem.updateInfo(
+                command.description(),
+                command.depositArea(),
+                validData.foundSchoolArea(),
+                command.foundAreaDetail(),
+                validData.category()
+        );
+
+        lostItemFeatureRepository.deleteByLostItemIds(List.of(lostItem.getId()));
+        if (validData.isNonETC()) {
+            List<LostItemFeature> newFeatures = validData.itemFeatureAndOptions().stream()
+                    .map(pair -> LostItemFeature.of(lostItem, pair.getFirst(), pair.getSecond()))
+                    .toList();
+            lostItemFeatureRepository.saveAll(newFeatures);
+        }
+
+        lostItem.approve();
+    }
+
+    public List<UploadedImageData> uploadImages(List<MultipartFile> images) {
+        if (images == null || images.isEmpty()) return List.of();
+
+        return IntStream.range(0, images.size())
+                .mapToObj(i -> {
+                    String url = s3ImageFileManager.upload(images.get(i), "lost-item-images");
+                    return new UploadedImageData(url, i);
+                })
+                .toList();
+    }
+
+    public void cleanupImages(List<UploadedImageData> images) {
+        if (images == null || images.isEmpty()) return;
+
+        s3FileCleanupService.cleanupOrphanFiles(
+                images.stream().map(UploadedImageData::url).toList()
+        );
+    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemStorageService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemStorageService.java
@@ -9,7 +9,6 @@ import com.greedy.zupzup.category.exception.LostItemFeatureException;
 import com.greedy.zupzup.category.repository.CategoryRepository;
 import com.greedy.zupzup.category.repository.FeatureOptionRepository;
 import com.greedy.zupzup.global.exception.ApplicationException;
-import com.greedy.zupzup.global.infrastructure.S3FileCleanupService;
 import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
 import com.greedy.zupzup.lostitem.application.dto.*;
 import com.greedy.zupzup.lostitem.domain.LostItem;
@@ -22,6 +21,8 @@ import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 import com.greedy.zupzup.schoolarea.repository.SchoolAreaRepository;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
@@ -35,13 +36,13 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class LostItemStorageService {
 
+    private static final String IMAGE_DIRECTORY = "lost-item-images";
     private final LostItemRepository lostItemRepository;
     private final LostItemImageRepository lostItemImageRepository;
     private final LostItemFeatureRepository lostItemFeatureRepository;
     private final FeatureOptionRepository featureOptionRepository;
     private final SchoolAreaRepository schoolAreaRepository;
     private final CategoryRepository categoryRepository;
-    private final S3FileCleanupService s3FileCleanupService;
     private final S3ImageFileManager s3ImageFileManager;
 
     /**
@@ -57,7 +58,8 @@ public class LostItemStorageService {
             return new LostItemRegisterData(category, foundSchoolArea, List.of());
         }
 
-        List<Pair<Feature, FeatureOption>> validFeatureAndOptions = getValidFeatureAndOptions(category, command.featureOptions());
+        List<Pair<Feature, FeatureOption>> validFeatureAndOptions = getValidFeatureAndOptions(category,
+                command.featureOptions());
         return new LostItemRegisterData(category, foundSchoolArea, validFeatureAndOptions);
     }
 
@@ -72,7 +74,8 @@ public class LostItemStorageService {
     private List<Pair<Feature, FeatureOption>> getValidFeatureAndOptions(Category category,
                                                                          List<ItemFeatureOptionCommand> requestedFeatureOptions) {
 
-        if (requestedFeatureOptions == null || requestedFeatureOptions.isEmpty() || category.getFeatures().size() != requestedFeatureOptions.size()) {
+        if (requestedFeatureOptions == null || requestedFeatureOptions.isEmpty()
+                || category.getFeatures().size() != requestedFeatureOptions.size()) {
             throw new ApplicationException(LostItemException.FEATURE_REQUIRED_FOR_NON_ETC_CATEGORY);
         }
 
@@ -80,7 +83,8 @@ public class LostItemStorageService {
         return requestedFeatureOptions.stream()
                 .map(featureOption -> {
                     Feature existsFeature = getValidFeature(category, featureOption.featureId());
-                    FeatureOption existsOption = getValidFeatureOption(options, existsFeature.getId(), featureOption.optionId());
+                    FeatureOption existsOption = getValidFeatureOption(options, existsFeature.getId(),
+                            featureOption.optionId());
                     return Pair.of(existsFeature, existsOption);
                 })
                 .toList();
@@ -100,7 +104,8 @@ public class LostItemStorageService {
                 .orElseThrow(() -> new ApplicationException(CategoryException.INVALID_CATEGORY_FEATURE));
     }
 
-    private FeatureOption getValidFeatureOption(List<FeatureOption> options, Long existsFeatureId, Long requestedOptionId) {
+    private FeatureOption getValidFeatureOption(List<FeatureOption> options, Long existsFeatureId,
+                                                Long requestedOptionId) {
         return options.stream()
                 .filter(option -> option.isValidSelection(existsFeatureId, requestedOptionId))
                 .findAny()
@@ -112,7 +117,8 @@ public class LostItemStorageService {
      * 2. 새로운 분실물 데이터를 등록
      */
     @Transactional
-    public LostItem createNewLostItem(CreateLostItemCommand command, LostItemRegisterData validatedData, List<UploadedImageData> uploadedImages) {
+    public LostItem createNewLostItem(CreateLostItemCommand command, LostItemRegisterData validatedData,
+                                      List<UploadedImageData> uploadedImages) {
 
         LostItem newLostItem = saveLostItem(command, validatedData.category(), validatedData.foundSchoolArea());
         saveLostItemImage(uploadedImages, newLostItem);
@@ -125,7 +131,8 @@ public class LostItemStorageService {
     }
 
     private LostItem saveLostItem(CreateLostItemCommand command, Category category, SchoolArea foundSchoolArea) {
-        LostItem newLostItem = new LostItem(command.foundAreaDetail(), command.description(), command.depositArea(), category, foundSchoolArea);
+        LostItem newLostItem = new LostItem(command.foundAreaDetail(), command.description(), command.depositArea(),
+                category, foundSchoolArea);
         lostItemRepository.save(newLostItem);
         return newLostItem;
     }
@@ -137,9 +144,11 @@ public class LostItemStorageService {
         lostItemImageRepository.saveAll(lostItemImages);
     }
 
-    private void saveLostItemFeatureAndOptions(List<Pair<Feature, FeatureOption>> itemFeatureAndOptions, LostItem newLostItem) {
+    private void saveLostItemFeatureAndOptions(List<Pair<Feature, FeatureOption>> itemFeatureAndOptions,
+                                               LostItem newLostItem) {
         List<LostItemFeature> newFeatures = itemFeatureAndOptions.stream()
-                .map(featureOption -> new LostItemFeature(newLostItem, featureOption.getFirst(), featureOption.getSecond()))
+                .map(featureOption -> new LostItemFeature(newLostItem, featureOption.getFirst(),
+                        featureOption.getSecond()))
                 .toList();
         lostItemFeatureRepository.saveAll(newFeatures);
     }
@@ -186,12 +195,7 @@ public class LostItemStorageService {
             saveLostItemFeatureAndOptions(validatedData.itemFeatureAndOptions(), lostItem);
         }
 
-        List<LostItemImage> toDeleteFromDb = existingImages.stream()
-                .filter(img -> !command.keepImageIds().contains(img.getId()))
-                .toList();
-        lostItemImageRepository.deleteAllInBatch(toDeleteFromDb);
-
-        saveLostItemImage(uploadedImages, lostItem);
+        updateImagesWithReindexing(lostItem, command.keepImageIds(), uploadedImages, existingImages);
 
         lostItem.updateAdmin(
                 command.description(),
@@ -205,11 +209,42 @@ public class LostItemStorageService {
         return oldKeysToDelete;
     }
 
+    private void updateImagesWithReindexing(
+            LostItem lostItem,
+            List<Long> keepImageIds,
+            List<UploadedImageData> uploadedImages,
+            List<LostItemImage> existingImages
+    ) {
+        List<LostItemImage> keptImages = existingImages.stream()
+                .filter(img -> keepImageIds.contains(img.getId()))
+                .sorted(Comparator.comparing(LostItemImage::getImageOrder))
+                .toList();
+
+        List<LostItemImage> newImageEntities = uploadedImages.stream()
+                .map(img -> new LostItemImage(img.url(), 0, lostItem))
+                .toList();
+
+        List<LostItemImage> toDeleteFromDb = existingImages.stream()
+                .filter(img -> !keepImageIds.contains(img.getId()))
+                .toList();
+        lostItemImageRepository.deleteAllInBatch(toDeleteFromDb);
+
+        List<LostItemImage> totalImages = new ArrayList<>();
+        totalImages.addAll(keptImages);
+        totalImages.addAll(newImageEntities);
+
+        IntStream.range(0, totalImages.size()).forEach(i -> {
+            totalImages.get(i).updateOrder(i);
+        });
+
+        lostItemImageRepository.saveAll(totalImages);
+    }
+
     public List<UploadedImageData> uploadImages(List<MultipartFile> files) {
         if (files == null || files.isEmpty()) return List.of();
 
         return IntStream.range(0, files.size())
-                .mapToObj(i -> new UploadedImageData(s3ImageFileManager.upload(files.get(i), "lost-items"), i))
+                .mapToObj(i -> new UploadedImageData(s3ImageFileManager.upload(files.get(i), IMAGE_DIRECTORY), i))
                 .toList();
     }
 

--- a/src/main/java/com/greedy/zupzup/lostitem/application/LostItemStorageService.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/application/LostItemStorageService.java
@@ -15,6 +15,7 @@ import com.greedy.zupzup.lostitem.application.dto.*;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.domain.LostItemImage;
+import com.greedy.zupzup.lostitem.domain.LostItemStatus;
 import com.greedy.zupzup.lostitem.exception.LostItemException;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
@@ -168,64 +169,55 @@ public class LostItemStorageService {
     }
 
     @Transactional
-    public void updateLostItem(LostItem lostItem, UpdateLostItemCommand command,
-                               LostItemRegisterData validData, List<Long> keepImageIds,
-                               List<UploadedImageData> uploadedImages, List<LostItemImage> existingImages) {
-
-        List<Long> safeKeepIds = (keepImageIds == null) ? List.of() : keepImageIds;
-        List<LostItemImage> toDelete = existingImages.stream()
-                .filter(img -> !safeKeepIds.contains(img.getId()))
+    public List<String> updateInTransaction(
+            LostItem lostItem,
+            UpdateLostItemCommand command,
+            LostItemRegisterData validatedData,
+            List<UploadedImageData> uploadedImages,
+            List<LostItemImage> existingImages
+    ) {
+        List<String> oldKeysToDelete = existingImages.stream()
+                .filter(img -> !command.keepImageIds().contains(img.getId()))
+                .map(LostItemImage::getImageKey)
                 .toList();
-
-        if (!toDelete.isEmpty()) {
-            lostItemImageRepository.deleteAll(toDelete);
-            s3FileCleanupService.cleanupOrphanFiles(
-                    toDelete.stream().map(LostItemImage::getImageKey).toList()
-            );
-        }
-
-        if (uploadedImages != null && !uploadedImages.isEmpty()) {
-            List<LostItemImage> newImages = uploadedImages.stream()
-                    .map(data -> LostItemImage.of(lostItem, data.url(), data.order()))
-                    .toList();
-            lostItemImageRepository.saveAll(newImages);
-        }
-
-        lostItem.updateInfo(
-                command.description(),
-                command.depositArea(),
-                validData.foundSchoolArea(),
-                command.foundAreaDetail(),
-                validData.category()
-        );
 
         lostItemFeatureRepository.deleteByLostItemIds(List.of(lostItem.getId()));
-        if (validData.isNonETC()) {
-            List<LostItemFeature> newFeatures = validData.itemFeatureAndOptions().stream()
-                    .map(pair -> LostItemFeature.of(lostItem, pair.getFirst(), pair.getSecond()))
-                    .toList();
-            lostItemFeatureRepository.saveAll(newFeatures);
+        if (validatedData.isNonETC()) {
+            saveLostItemFeatureAndOptions(validatedData.itemFeatureAndOptions(), lostItem);
         }
 
-        lostItem.approve();
+        List<LostItemImage> toDeleteFromDb = existingImages.stream()
+                .filter(img -> !command.keepImageIds().contains(img.getId()))
+                .toList();
+        lostItemImageRepository.deleteAllInBatch(toDeleteFromDb);
+
+        saveLostItemImage(uploadedImages, lostItem);
+
+        lostItem.updateAdmin(
+                command.description(),
+                command.depositArea(),
+                validatedData.foundSchoolArea(),
+                validatedData.category(),
+                command.foundAreaDetail(),
+                LostItemStatus.REGISTERED
+        );
+
+        return oldKeysToDelete;
     }
 
-    public List<UploadedImageData> uploadImages(List<MultipartFile> images) {
-        if (images == null || images.isEmpty()) return List.of();
+    public List<UploadedImageData> uploadImages(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) return List.of();
 
-        return IntStream.range(0, images.size())
-                .mapToObj(i -> {
-                    String url = s3ImageFileManager.upload(images.get(i), "lost-item-images");
-                    return new UploadedImageData(url, i);
-                })
+        return IntStream.range(0, files.size())
+                .mapToObj(i -> new UploadedImageData(s3ImageFileManager.upload(files.get(i), "lost-items"), i))
                 .toList();
     }
 
-    public void cleanupImages(List<UploadedImageData> images) {
-        if (images == null || images.isEmpty()) return;
+    public void cleanupImages(List<UploadedImageData> uploadedImages) {
+        uploadedImages.forEach(img -> s3ImageFileManager.delete(img.url()));
+    }
 
-        s3FileCleanupService.cleanupOrphanFiles(
-                images.stream().map(UploadedImageData::url).toList()
-        );
+    public void deleteOldImages(List<String> keys) {
+        keys.forEach(s3ImageFileManager::delete);
     }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
@@ -62,7 +62,8 @@ public class LostItem extends BaseTimeEntity {
     @OneToMany(mappedBy = "lostItem")
     private List<LostItemImage> images = new ArrayList<>();
 
-    public LostItem(String foundAreaDetail, String description, String depositArea, Category category, SchoolArea foundArea) {
+    public LostItem(String foundAreaDetail, String description, String depositArea, Category category,
+                    SchoolArea foundArea) {
         this.foundAreaDetail = foundAreaDetail;
         this.description = description;
         this.depositArea = depositArea;
@@ -99,12 +100,26 @@ public class LostItem extends BaseTimeEntity {
     }
 
     public boolean canAccess(boolean pledgedByMe) {
-        if (this.status == LostItemStatus.FOUND) return false;
-        if (this.status == LostItemStatus.PLEDGED && !pledgedByMe) return false;
+        if (this.status == LostItemStatus.FOUND) {
+            return false;
+        }
+        if (this.status == LostItemStatus.PLEDGED && !pledgedByMe) {
+            return false;
+        }
         return true;
     }
 
     public void changeStatus(LostItemStatus status) {
+        this.status = status;
+    }
+
+    public void updateAdmin(String description, String depositArea, SchoolArea foundArea,
+                            Category category, String foundAreaDetail, LostItemStatus status) {
+        this.description = description;
+        this.depositArea = depositArea;
+        this.foundArea = foundArea;
+        this.category = category;
+        this.foundAreaDetail = foundAreaDetail;
         this.status = status;
     }
 
@@ -125,11 +140,5 @@ public class LostItem extends BaseTimeEntity {
 
     public boolean isPledged() {
         return this.status == LostItemStatus.PLEDGED;
-    }
-
-    public void approve() {
-        if (this.status == LostItemStatus.PENDING) {
-            this.status = LostItemStatus.REGISTERED;
-        }
     }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItem.java
@@ -72,6 +72,15 @@ public class LostItem extends BaseTimeEntity {
         this.foundArea = foundArea;
     }
 
+    public void updateInfo(String description, String depositArea, SchoolArea foundArea,
+                           String foundAreaDetail, Category category) {
+        this.description = description;
+        this.depositArea = depositArea;
+        this.foundArea = foundArea;
+        this.foundAreaDetail = foundAreaDetail;
+        this.category = category;
+    }
+
     public boolean isEtcCategory() {
         return this.category.isEtcCategory();
     }
@@ -118,4 +127,9 @@ public class LostItem extends BaseTimeEntity {
         return this.status == LostItemStatus.PLEDGED;
     }
 
+    public void approve() {
+        if (this.status == LostItemStatus.PENDING) {
+            this.status = LostItemStatus.REGISTERED;
+        }
+    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItemFeature.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItemFeature.java
@@ -50,6 +50,10 @@ public class LostItemFeature extends BaseTimeEntity {
         this.selectedOption = selectedOption;
     }
 
+    public static LostItemFeature of(LostItem lostItem, Feature feature, FeatureOption selectedOption) {
+        return new LostItemFeature(lostItem, feature, selectedOption);
+    }
+
     public Long getFeatureId() {
         return this.feature.getId();
     }

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItemImage.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItemImage.java
@@ -47,4 +47,8 @@ public class LostItemImage extends BaseTimeEntity {
     public static LostItemImage of(LostItem lostItem, String imageKey, Integer imageOrder) {
         return new LostItemImage(imageKey, imageOrder, lostItem);
     }
+
+    public void updateOrder(int newOrder) {
+        this.imageOrder = newOrder;
+    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/domain/LostItemImage.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/domain/LostItemImage.java
@@ -43,4 +43,8 @@ public class LostItemImage extends BaseTimeEntity {
         this.imageOrder = imageOrder;
         this.lostItem = lostItem;
     }
+
+    public static LostItemImage of(LostItem lostItem, String imageKey, Integer imageOrder) {
+        return new LostItemImage(imageKey, imageOrder, lostItem);
+    }
 }

--- a/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
@@ -20,7 +20,9 @@ public enum LostItemException implements ExceptionCode {
     PLEDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "서약 정보 없음", "해당 분실물에 대한 서약 정보가 존재하지 않습니다."),
     PLEDGE_NOT_BY_THIS_USER(HttpStatus.FORBIDDEN, "권한 없음", "해당 서약은 현재 사용자에 의해 만들어진 것이 아닙니다."),
     INVALID_STATUS_FOR_PLEDGE_CANCEL(HttpStatus.CONFLICT, "서약 취소 불가 상태", "현재 상태에서는 서약을 취소할 수 없습니다."),
-    INVALID_STATUS_FOR_PLEDGE_COMPLETE(HttpStatus.CONFLICT, "습득 완료 처리 불가 상태", "현재 상태에서는 분실물을 습득 완료 처리할 수 없습니다.");
+    INVALID_STATUS_FOR_PLEDGE_COMPLETE(HttpStatus.CONFLICT, "습득 완료 처리 불가 상태", "현재 상태에서는 분실물을 습득 완료 처리할 수 없습니다."),
+    INVALID_IMAGE_ACCESS(HttpStatus.BAD_REQUEST, "잘못된 이미지 접근", "해당 분실물에 속하지 않은 이미지가 포함되어 있습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String title;

--- a/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/exception/LostItemException.java
@@ -17,6 +17,7 @@ public enum LostItemException implements ExceptionCode {
     ACCESS_FORBIDDEN_FOUND(HttpStatus.FORBIDDEN, "접근이 제한되었습니다.", "이미 주인이 찾아간 분실물로, 조회가 제한됩니다."),
     FEATURE_REQUIRED_FOR_NON_ETC_CATEGORY(HttpStatus.BAD_REQUEST, "분실물 특징 입력 누락", "분실물 카테고리가 '기타'가 아닌 경우, 필수 특징값이 모두 입력되어야 합니다."),
     REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "분실물 등록 실패", "분실물 저장 중 예상치 못한 오류가 발생했습니다."),
+    UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "분실물 수정 실패", "분실물 수정 중 예상치 못한 오류가 발생했습니다."),
     PLEDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "서약 정보 없음", "해당 분실물에 대한 서약 정보가 존재하지 않습니다."),
     PLEDGE_NOT_BY_THIS_USER(HttpStatus.FORBIDDEN, "권한 없음", "해당 서약은 현재 사용자에 의해 만들어진 것이 아닙니다."),
     INVALID_STATUS_FOR_PLEDGE_CANCEL(HttpStatus.CONFLICT, "서약 취소 불가 상태", "현재 상태에서는 서약을 취소할 수 없습니다."),

--- a/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemImageRepository.java
+++ b/src/main/java/com/greedy/zupzup/lostitem/repository/LostItemImageRepository.java
@@ -40,4 +40,20 @@ public interface LostItemImageRepository extends JpaRepository<LostItemImage, Lo
             """)
     List<LostItemImage> findImagesForItems(@Param("lostItemIds") List<Long> lostItemIds);
 
+    @Query("""
+    select i
+    from LostItemImage i
+    where i.lostItem.id = :lostItemId
+    order by i.imageOrder asc
+""")
+    List<LostItemImage> findByLostItemId(@Param("lostItemId") Long lostItemId);
+
+    @Query("""
+    select count(i)
+    from LostItemImage i
+    where i.id in :ids
+      and i.lostItem.id = :lostItemId
+""")
+    long countByIdInAndLostItemId(@Param("ids") List<Long> ids, @Param("lostItemId") Long lostItemId);
+
 }

--- a/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
@@ -23,6 +23,7 @@ import com.greedy.zupzup.category.domain.Feature;
 import com.greedy.zupzup.category.domain.FeatureOption;
 import com.greedy.zupzup.common.ServiceUnitTest;
 import com.greedy.zupzup.lostitem.application.dto.LostItemRegisterData;
+import com.greedy.zupzup.lostitem.application.dto.UploadedImageData;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.domain.LostItemImage;
@@ -169,78 +170,60 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
         });
     }
 
-    private UpdateLostItemCommand validCommand() {
+    private UpdateLostItemCommand validCommand(Long lostItemId, List<Long> keepImageIds) {
         return new UpdateLostItemCommand(
+                lostItemId,
                 "설명 수정",
                 "보관 장소",
                 1L,
                 "발견 위치",
                 10L,
                 List.of(),
-                List.of(10L)
+                keepImageIds,
+                List.of() // newImages
         );
     }
-
     private LostItem pendingLostItem(Long id) {
         return mock(LostItem.class);
     }
 
 
     @Test
-    void 관리자_분실물_수정시_기존이미지만_유지하고_정보를_수정해도_승인된다() {
-        Long lostItemId = 1L;
-        LostItem item = pendingLostItem(lostItemId);
-
-        lenient().when(item.getStatus()).thenReturn(LostItemStatus.PENDING);
-
-        given(adminLostItemRepository.findById(lostItemId)).willReturn(Optional.of(item));
-
-        setupValidRegisterData();
-
-        LostItemImage existingImg = mock(LostItemImage.class);
-        given(existingImg.getId()).willReturn(10L);
-        given(lostItemImageRepository.findByLostItemId(lostItemId)).willReturn(List.of(existingImg));
-
-        UpdateLostItemCommand command = validCommand();
-        List<Long> keepImageIds = List.of(10L);
-
-        UpdateLostItemResult result =
-                service.updateLostItem(lostItemId, command, List.of());
-
-        then(lostItemStorageService).should().updateLostItem(
-                eq(item), eq(command), any(LostItemRegisterData.class),
-                eq(keepImageIds), any(), any()
-        );
-
-        assertThat(result.lostItemId()).isEqualTo(lostItemId);
-    }
-
-    @Test
-    void 관리자_분실물_수정시_기존이미지는_유지하고_새이미지를_추가한뒤_승인한다() {
+    void 관리자_분실물_수정시_S3업로드와_DB트랜잭션을_순차적으로_호출한다() {
         // given
         Long lostItemId = 1L;
-        LostItem item = pendingLostItem(lostItemId);
+        List<Long> keepImageIds = List.of(10L);
+        UpdateLostItemCommand command = validCommand(lostItemId, keepImageIds);
 
-        lenient().when(item.getStatus()).thenReturn(LostItemStatus.PENDING);
-
-        setupValidRegisterData();
-
+        LostItem item = mock(LostItem.class);
+        given(item.getStatus()).willReturn(LostItemStatus.PENDING);
         given(adminLostItemRepository.findById(lostItemId)).willReturn(Optional.of(item));
 
         LostItemImage existingImg = mock(LostItemImage.class);
         given(existingImg.getId()).willReturn(10L);
         given(lostItemImageRepository.findByLostItemId(lostItemId)).willReturn(List.of(existingImg));
 
-        UpdateLostItemCommand command = validCommand();
-        List<Long> keepImageIds = List.of(10L);
-        List<MultipartFile> newImages = List.of(mock(MultipartFile.class));
+        LostItemRegisterData mockRegData = mock(LostItemRegisterData.class);
+        given(lostItemStorageService.getValidUpdateData(command)).willReturn(mockRegData);
+
+        List<UploadedImageData> mockUploads = List.of(new UploadedImageData("url", 0));
+        given(lostItemStorageService.uploadImages(any())).willReturn(mockUploads);
+
+        List<String> oldKeys = List.of("oldKey");
+        given(lostItemStorageService.updateInTransaction(eq(item), eq(command), eq(mockRegData), any(), any()))
+                .willReturn(oldKeys);
 
         // when
-        service.updateLostItem(lostItemId, command, List.of());
+        UpdateLostItemResult result = service.updateLostItem(command);
 
         // then
-        then(lostItemStorageService).should().updateLostItem(
-                eq(item), eq(command), any(LostItemRegisterData.class), eq(keepImageIds), any(), any()
-        );
+        assertSoftly(s -> {
+            s.assertThat(result.lostItemId()).isEqualTo(lostItemId);
+        });
+
+        // 호출 순서 및 위임 검증
+        then(lostItemStorageService).should().uploadImages(any());
+        then(lostItemStorageService).should().updateInTransaction(eq(item), eq(command), eq(mockRegData), any(), any());
+        then(lostItemStorageService).should().deleteOldImages(oldKeys);
     }
 }

--- a/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
@@ -17,7 +17,7 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
+import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemCommand;
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.domain.Feature;
 import com.greedy.zupzup.category.domain.FeatureOption;
@@ -41,7 +41,6 @@ import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.multipart.MultipartFile;
 
 public class AdminLostItemServiceTest extends ServiceUnitTest {
 

--- a/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
@@ -171,7 +171,13 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
 
     private UpdateLostItemCommand validCommand() {
         return new UpdateLostItemCommand(
-                "설명 수정", "보관 장소", 1L, "발견 위치", 10L, List.of()
+                "설명 수정",
+                "보관 장소",
+                1L,
+                "발견 위치",
+                10L,
+                List.of(),
+                List.of(10L)
         );
     }
 
@@ -199,7 +205,7 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
         List<Long> keepImageIds = List.of(10L);
 
         UpdateLostItemResult result =
-                service.updateLostItem(lostItemId, command, keepImageIds, List.of());
+                service.updateLostItem(lostItemId, command, List.of());
 
         then(lostItemStorageService).should().updateLostItem(
                 eq(item), eq(command), any(LostItemRegisterData.class),
@@ -230,7 +236,7 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
         List<MultipartFile> newImages = List.of(mock(MultipartFile.class));
 
         // when
-        service.updateLostItem(lostItemId, command, keepImageIds, newImages);
+        service.updateLostItem(lostItemId, command, List.of());
 
         // then
         then(lostItemStorageService).should().updateLostItem(

--- a/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
@@ -1,40 +1,38 @@
 package com.greedy.zupzup.admin.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 import com.greedy.zupzup.admin.lostitem.application.AdminLostItemService;
-import com.greedy.zupzup.admin.lostitem.application.dto.AdminFeatureOptionDto;
 import com.greedy.zupzup.admin.lostitem.application.dto.ItemImageBulkDeletedEvent;
+import com.greedy.zupzup.admin.lostitem.application.dto.UpdateLostItemResult;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.AdminPendingLostItemListResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
-import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemCommand;
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.domain.Feature;
+import com.greedy.zupzup.category.domain.FeatureOption;
 import com.greedy.zupzup.common.ServiceUnitTest;
 import com.greedy.zupzup.lostitem.application.dto.LostItemRegisterData;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.domain.LostItemImage;
 import com.greedy.zupzup.lostitem.domain.LostItemStatus;
-
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import com.greedy.zupzup.category.domain.FeatureOption;
 import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -54,9 +52,11 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
 
     private void setupValidRegisterData() {
         LostItemRegisterData mockData = mock(LostItemRegisterData.class);
-        given(mockData.foundSchoolArea()).willReturn(mock(SchoolArea.class));
-        given(mockData.category()).willReturn(mock(Category.class));
-        given(lostItemStorageService.getValidRegisterData(any())).willReturn(mockData);
+        lenient().when(mockData.foundSchoolArea()).thenReturn(mock(SchoolArea.class));
+        lenient().when(mockData.category()).thenReturn(mock(Category.class));
+
+        given(lostItemStorageService.getValidUpdateData(any(UpdateLostItemCommand.class)))
+                .willReturn(mockData);
     }
 
     private LostItem stubItem(
@@ -100,8 +100,7 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
     }
 
     @Test
-    void 일괄_삭제시_DB삭제_및_이벤트를_발행한다() { // [수정] 테스트 이름
-        // given
+    void 일괄_삭제시_DB삭제_및_이벤트를_발행한다() {
         List<Long> ids = List.of(1L, 2L);
         RejectLostItemsRequest req = new RejectLostItemsRequest(ids);
         List<String> expectedImageUrls = List.of("k1", "k2");
@@ -110,33 +109,26 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
                 .willReturn(expectedImageUrls);
         given(adminLostItemRepository.deleteBulkByIds(ids)).willReturn(2);
 
-        // when
         RejectLostItemsResponse res = service.rejectBulk(req);
 
-        // then
-        // 1. 응답 결과 검증
         assertSoftly(s -> {
             s.assertThat(res.successfulCount()).isEqualTo(2);
         });
 
-        // 2. DB 삭제 로직 호출 검증
         then(lostItemFeatureRepository).should().deleteByLostItemIds(ids);
         then(lostItemImageRepository).should().deleteByLostItemIds(ids);
         then(adminLostItemRepository).should().deleteBulkByIds(ids);
 
-        // 4. 이벤트 발행 검증
-        ArgumentCaptor<ItemImageBulkDeletedEvent> eventCaptor =
+        ArgumentCaptor<ItemImageBulkDeletedEvent> captor =
                 ArgumentCaptor.forClass(ItemImageBulkDeletedEvent.class);
 
-        then(eventPublisher).should().publishEvent(eventCaptor.capture());
-        ItemImageBulkDeletedEvent publishedEvent = eventCaptor.getValue();
-        assertThat(publishedEvent.imageUrls()).isEqualTo(expectedImageUrls);
+        then(eventPublisher).should().publishEvent(captor.capture());
+        assertThat(captor.getValue().imageUrls()).isEqualTo(expectedImageUrls);
     }
 
     @Test
     void 보류중_분실물_목록을_조회한다() {
-        int page = 1, limit = 10;
-        Pageable pageable = PageRequest.of(page - 1, limit);
+        Pageable pageable = PageRequest.of(0, 10);
 
         LostItem i1 = stubItem(1L, "아이폰", "학생회관", "도서관3층", 10L, "전자제품", 1L, "AI센터");
         LostItem i2 = stubItem(2L, "지갑", "경비실", "운동장", 11L, "지갑", 2L, "정문");
@@ -158,69 +150,63 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
         Feature feature = mock(Feature.class);
         given(feature.getQuizQuestion()).willReturn("제조사는 무엇인가요?");
 
-        FeatureOption fopt = mock(FeatureOption.class);
-        given(fopt.getId()).willReturn(100L);
-        given(fopt.getOptionValue()).willReturn("삼성");
-        given(fopt.getFeature()).willReturn(feature);
+        FeatureOption option = mock(FeatureOption.class);
+        given(option.getOptionValue()).willReturn("삼성");
+        given(option.getFeature()).willReturn(feature);
 
         LostItemFeature lf = mock(LostItemFeature.class);
         given(lf.getLostItem()).willReturn(i1);
-        given(lf.getSelectedOption()).willReturn(fopt);
+        given(lf.getSelectedOption()).willReturn(option);
 
         given(lostItemFeatureRepository.findFeaturesForLostItems(List.of(1L, 2L)))
                 .willReturn(List.of(lf));
 
-        AdminPendingLostItemListResponse res = service.getPendingLostItems(page, limit);
+        AdminPendingLostItemListResponse res = service.getPendingLostItems(1, 10);
 
         assertSoftly(s -> {
             s.assertThat(res.count()).isEqualTo(2);
             s.assertThat(res.items()).hasSize(2);
-            s.assertThat(res.items().get(0).id()).isEqualTo(1L);
-            s.assertThat(res.items().get(0).imageUrl()).contains("img1");
-
-            AdminFeatureOptionDto dto = res.items().get(0).featureOptions().get(0);
-            s.assertThat(dto.optionValue()).isEqualTo("삼성");
-            s.assertThat(dto.quizQuestion()).isEqualTo("제조사는 무엇인가요?");
         });
     }
 
-
-    private UpdateLostItemRequest validRequest() {
-        return new UpdateLostItemRequest(
-                "설명 수정",
-                "보관 장소",
-                1L,
-                "발견 위치",
-                10L,
-                List.of() // featureOptions
+    private UpdateLostItemCommand validCommand() {
+        return new UpdateLostItemCommand(
+                "설명 수정", "보관 장소", 1L, "발견 위치", 10L, List.of()
         );
     }
 
     private LostItem pendingLostItem(Long id) {
-        LostItem item = mock(LostItem.class);
-        given(item.getId()).willReturn(id);
-        given(item.getStatus()).willReturn(LostItemStatus.PENDING);
-        return item;
+        return mock(LostItem.class);
     }
+
 
     @Test
     void 관리자_분실물_수정시_기존이미지만_유지하고_정보를_수정해도_승인된다() {
-        // given
         Long lostItemId = 1L;
         LostItem item = pendingLostItem(lostItemId);
-        setupValidRegisterData();
+
+        lenient().when(item.getStatus()).thenReturn(LostItemStatus.PENDING);
 
         given(adminLostItemRepository.findById(lostItemId)).willReturn(Optional.of(item));
 
+        setupValidRegisterData();
+
+        LostItemImage existingImg = mock(LostItemImage.class);
+        given(existingImg.getId()).willReturn(10L);
+        given(lostItemImageRepository.findByLostItemId(lostItemId)).willReturn(List.of(existingImg));
+
+        UpdateLostItemCommand command = validCommand();
         List<Long> keepImageIds = List.of(10L);
-        given(lostItemImageRepository.countByIdInAndLostItemId(keepImageIds, lostItemId)).willReturn(1L);
-        given(lostItemImageRepository.findByLostItemId(lostItemId)).willReturn(List.of(mock(LostItemImage.class)));
 
-        // when
-        service.updateLostItem(lostItemId, validRequest(), keepImageIds, List.of());
+        UpdateLostItemResult result =
+                service.updateLostItem(lostItemId, command, keepImageIds, List.of());
 
-        // then
-        then(item).should().approve();
+        then(lostItemStorageService).should().updateLostItem(
+                eq(item), eq(command), any(LostItemRegisterData.class),
+                eq(keepImageIds), any(), any()
+        );
+
+        assertThat(result.lostItemId()).isEqualTo(lostItemId);
     }
 
     @Test
@@ -228,20 +214,27 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
         // given
         Long lostItemId = 1L;
         LostItem item = pendingLostItem(lostItemId);
+
+        lenient().when(item.getStatus()).thenReturn(LostItemStatus.PENDING);
+
         setupValidRegisterData();
 
         given(adminLostItemRepository.findById(lostItemId)).willReturn(Optional.of(item));
 
+        LostItemImage existingImg = mock(LostItemImage.class);
+        given(existingImg.getId()).willReturn(10L);
+        given(lostItemImageRepository.findByLostItemId(lostItemId)).willReturn(List.of(existingImg));
+
+        UpdateLostItemCommand command = validCommand();
         List<Long> keepImageIds = List.of(10L);
-        given(lostItemImageRepository.countByIdInAndLostItemId(keepImageIds, lostItemId)).willReturn(1L);
-        given(lostItemImageRepository.findByLostItemId(lostItemId)).willReturn(List.of(mock(LostItemImage.class)));
-        given(s3ImageFileManager.upload(any(), any())).willReturn("new-img-url");
+        List<MultipartFile> newImages = List.of(mock(MultipartFile.class));
 
         // when
-        service.updateLostItem(lostItemId, validRequest(), keepImageIds, List.of(mock(MultipartFile.class)));
+        service.updateLostItem(lostItemId, command, keepImageIds, newImages);
 
         // then
-        then(item).should().approve();
-        then(lostItemImageRepository).should().saveAll(any());
+        then(lostItemStorageService).should().updateLostItem(
+                eq(item), eq(command), any(LostItemRegisterData.class), eq(keepImageIds), any(), any()
+        );
     }
 }

--- a/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/admin/application/AdminLostItemServiceTest.java
@@ -1,10 +1,14 @@
 package com.greedy.zupzup.admin.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 import com.greedy.zupzup.admin.lostitem.application.AdminLostItemService;
 import com.greedy.zupzup.admin.lostitem.application.dto.AdminFeatureOptionDto;
@@ -14,20 +18,23 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsResponse;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsResponse;
-import com.greedy.zupzup.admin.lostitem.repository.AdminLostItemRepository;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.category.domain.Feature;
 import com.greedy.zupzup.common.ServiceUnitTest;
+import com.greedy.zupzup.lostitem.application.dto.LostItemRegisterData;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemFeature;
 import com.greedy.zupzup.lostitem.domain.LostItemImage;
 import com.greedy.zupzup.lostitem.domain.LostItemStatus;
+
 import com.greedy.zupzup.schoolarea.domain.SchoolArea;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import com.greedy.zupzup.category.domain.FeatureOption;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -35,6 +42,7 @@ import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 public class AdminLostItemServiceTest extends ServiceUnitTest {
 
@@ -42,11 +50,14 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
     private AdminLostItemService service;
 
     @Mock
-    private AdminLostItemRepository adminLostItemRepository;
-
-    @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    private void setupValidRegisterData() {
+        LostItemRegisterData mockData = mock(LostItemRegisterData.class);
+        given(mockData.foundSchoolArea()).willReturn(mock(SchoolArea.class));
+        given(mockData.category()).willReturn(mock(Category.class));
+        given(lostItemStorageService.getValidRegisterData(any())).willReturn(mockData);
+    }
 
     private LostItem stubItem(
             Long id, String desc, String deposit, String foundDetail,
@@ -171,5 +182,66 @@ public class AdminLostItemServiceTest extends ServiceUnitTest {
             s.assertThat(dto.optionValue()).isEqualTo("삼성");
             s.assertThat(dto.quizQuestion()).isEqualTo("제조사는 무엇인가요?");
         });
+    }
+
+
+    private UpdateLostItemRequest validRequest() {
+        return new UpdateLostItemRequest(
+                "설명 수정",
+                "보관 장소",
+                1L,
+                "발견 위치",
+                10L,
+                List.of() // featureOptions
+        );
+    }
+
+    private LostItem pendingLostItem(Long id) {
+        LostItem item = mock(LostItem.class);
+        given(item.getId()).willReturn(id);
+        given(item.getStatus()).willReturn(LostItemStatus.PENDING);
+        return item;
+    }
+
+    @Test
+    void 관리자_분실물_수정시_기존이미지만_유지하고_정보를_수정해도_승인된다() {
+        // given
+        Long lostItemId = 1L;
+        LostItem item = pendingLostItem(lostItemId);
+        setupValidRegisterData();
+
+        given(adminLostItemRepository.findById(lostItemId)).willReturn(Optional.of(item));
+
+        List<Long> keepImageIds = List.of(10L);
+        given(lostItemImageRepository.countByIdInAndLostItemId(keepImageIds, lostItemId)).willReturn(1L);
+        given(lostItemImageRepository.findByLostItemId(lostItemId)).willReturn(List.of(mock(LostItemImage.class)));
+
+        // when
+        service.updateLostItem(lostItemId, validRequest(), keepImageIds, List.of());
+
+        // then
+        then(item).should().approve();
+    }
+
+    @Test
+    void 관리자_분실물_수정시_기존이미지는_유지하고_새이미지를_추가한뒤_승인한다() {
+        // given
+        Long lostItemId = 1L;
+        LostItem item = pendingLostItem(lostItemId);
+        setupValidRegisterData();
+
+        given(adminLostItemRepository.findById(lostItemId)).willReturn(Optional.of(item));
+
+        List<Long> keepImageIds = List.of(10L);
+        given(lostItemImageRepository.countByIdInAndLostItemId(keepImageIds, lostItemId)).willReturn(1L);
+        given(lostItemImageRepository.findByLostItemId(lostItemId)).willReturn(List.of(mock(LostItemImage.class)));
+        given(s3ImageFileManager.upload(any(), any())).willReturn("new-img-url");
+
+        // when
+        service.updateLostItem(lostItemId, validRequest(), keepImageIds, List.of(mock(MultipartFile.class)));
+
+        // then
+        then(item).should().approve();
+        then(lostItemImageRepository).should().saveAll(any());
     }
 }

--- a/src/test/java/com/greedy/zupzup/admin/presentation/AdminLostItemControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/admin/presentation/AdminLostItemControllerTest.java
@@ -2,6 +2,7 @@ package com.greedy.zupzup.admin.presentation;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
@@ -15,8 +16,10 @@ import com.greedy.zupzup.lostitem.presentation.dto.ItemFeatureRequest;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.member.domain.Member;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,6 +51,15 @@ class AdminLostItemControllerTest extends ControllerTest {
         adminMember = givenAdmin("admin_pw");
         adminToken = givenAccessToken(adminMember);
         category = givenElectronicsCategory();
+    }
+
+    @BeforeEach
+    void setUpRestAssured() {
+        RestAssured.config = RestAssured.config()
+                .encoderConfig(
+                        io.restassured.config.EncoderConfig.encoderConfig()
+                                .defaultContentCharset("UTF-8")
+                );
     }
 
     @Nested
@@ -224,65 +236,87 @@ class AdminLostItemControllerTest extends ControllerTest {
             LostItem item = givenPendingLostItemWithFeatures(category);
             givenLostItemImages(item.getId(), List.of("img1", "img2"));
 
-            List<ItemFeatureRequest> featureOptions = List.of(
-                    new ItemFeatureRequest(1L, 1L),
-                    new ItemFeatureRequest(2L, 5L)
-            );
-
             List<Long> keepImageIds = List.of(
                     lostItemImageRepository.findByLostItemId(item.getId()).get(0).getId()
             );
 
-            UpdateLostItemRequest updateRequest = new UpdateLostItemRequest(
+            List<ItemFeatureRequest> features = List.of(
+                    new ItemFeatureRequest(1L, 1L),
+                    new ItemFeatureRequest(2L, 5L)
+            );
+
+            UpdateLostItemRequest request = new UpdateLostItemRequest(
                     "수정된 설명",
                     "학생회관",
                     1L,
                     "1층",
                     category.getId(),
-                    featureOptions
+                    features,
+                    keepImageIds
             );
 
             // when
-            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+            ExtractableResponse<Response> res = RestAssured.given()
                     .cookie(ACCESS_TOKEN_NAME, adminToken)
-                    .contentType("multipart/form-data")
-                    .multiPart("keepImageIds", objectMapper.writeValueAsString(keepImageIds), "application/json")
-                    .multiPart("updateRequest", objectMapper.writeValueAsString(updateRequest), "application/json")
+                    .contentType(ContentType.MULTIPART)
+                    .multiPart(
+                            "updateRequest",
+                            "updateRequest",
+                            objectMapper.writeValueAsBytes(request),
+                            "application/json"
+                    )
                     .when()
                     .put("/api/admin/lost-items/" + item.getId())
-                    .then().log().all()
+                    .then()
                     .extract();
 
             // then
-            assertSoftly(softly -> {
-                softly.assertThat(extract.statusCode()).isEqualTo(200);
+            assertSoftly(s -> {
+                s.assertThat(res.statusCode()).isEqualTo(200);
+
                 LostItem updated = lostItemRepository.findById(item.getId()).orElseThrow();
-                softly.assertThat(updated.getStatus()).isEqualTo(LostItemStatus.REGISTERED);
+
+                s.assertThat(updated.getStatus()).isEqualTo(LostItemStatus.REGISTERED);
+                s.assertThat(updated.getDescription()).isEqualTo("수정된 설명");
+
+                List<Long> imageIds = lostItemImageRepository.findByLostItemId(item.getId())
+                        .stream()
+                        .map(img -> img.getId())
+                        .toList();
+
+                s.assertThat(imageIds).containsExactlyInAnyOrderElementsOf(keepImageIds);
             });
         }
 
         @Test
         void 이미_승인된_분실물을_수정하려고_하면_403_FORBIDDEN을_응답한다() throws Exception {
-            // given
-            LostItem registeredItem = givenRegisteredLostItem(category);
+            LostItem item = givenRegisteredLostItem(category);
 
-            UpdateLostItemRequest updateRequest = new UpdateLostItemRequest(
-                    "수정 시도", "장소", 1L, "상세", category.getId(), List.of()
+            UpdateLostItemRequest request = new UpdateLostItemRequest(
+                    "수정",
+                    "장소",
+                    1L,
+                    "상세",
+                    category.getId(),
+                    List.of(),
+                    List.of()
             );
 
-            // when
-            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+            ExtractableResponse<Response> res = RestAssured.given()
                     .cookie(ACCESS_TOKEN_NAME, adminToken)
-                    .contentType("multipart/form-data")
-                    .multiPart("keepImageIds", "[]", "application/json")
-                    .multiPart("updateRequest", objectMapper.writeValueAsString(updateRequest), "application/json")
+                    .contentType(ContentType.MULTIPART)
+                    .multiPart(
+                            "updateRequest",
+                            objectMapper.writeValueAsString(request),
+                            "application/json"
+                    )
                     .when()
-                    .put("/api/admin/lost-items/" + registeredItem.getId())
-                    .then().log().all()
+                    .put("/api/admin/lost-items/" + item.getId())
+                    .then()
                     .extract();
 
-            // then
-            assertThat(extract.statusCode()).isEqualTo(403);
+            assertThat(res.statusCode()).isEqualTo(403);
         }
+
     }
 }

--- a/src/test/java/com/greedy/zupzup/admin/presentation/AdminLostItemControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/admin/presentation/AdminLostItemControllerTest.java
@@ -1,9 +1,7 @@
 package com.greedy.zupzup.admin.presentation;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
@@ -16,7 +14,6 @@ import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
 import com.greedy.zupzup.lostitem.presentation.dto.ItemFeatureRequest;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.member.domain.Member;
-import com.greedy.zupzup.member.repository.MemberRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -27,10 +24,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
-import jakarta.servlet.http.Cookie;
 
 class AdminLostItemControllerTest extends ControllerTest {
 
@@ -46,11 +40,6 @@ class AdminLostItemControllerTest extends ControllerTest {
     @Autowired
     private LostItemRepository lostItemRepository;
 
-    @Autowired
-    private MemberRepository memberRepository;
-
-    private Cookie adminCookie;
-    private Long lostItemId;
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -270,6 +259,30 @@ class AdminLostItemControllerTest extends ControllerTest {
                 LostItem updated = lostItemRepository.findById(item.getId()).orElseThrow();
                 softly.assertThat(updated.getStatus()).isEqualTo(LostItemStatus.REGISTERED);
             });
+        }
+
+        @Test
+        void 이미_승인된_분실물을_수정하려고_하면_403_FORBIDDEN을_응답한다() throws Exception {
+            // given
+            LostItem registeredItem = givenRegisteredLostItem(category);
+
+            UpdateLostItemRequest updateRequest = new UpdateLostItemRequest(
+                    "수정 시도", "장소", 1L, "상세", category.getId(), List.of()
+            );
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .cookie(ACCESS_TOKEN_NAME, adminToken)
+                    .contentType("multipart/form-data")
+                    .multiPart("keepImageIds", "[]", "application/json")
+                    .multiPart("updateRequest", objectMapper.writeValueAsString(updateRequest), "application/json")
+                    .when()
+                    .put("/api/admin/lost-items/" + registeredItem.getId())
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(extract.statusCode()).isEqualTo(403);
         }
     }
 }

--- a/src/test/java/com/greedy/zupzup/admin/presentation/AdminLostItemControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/admin/presentation/AdminLostItemControllerTest.java
@@ -1,14 +1,22 @@
 package com.greedy.zupzup.admin.presentation;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.greedy.zupzup.admin.lostitem.presentation.dto.UpdateLostItemRequest;
 import com.greedy.zupzup.category.domain.Category;
 import com.greedy.zupzup.common.ControllerTest;
 import com.greedy.zupzup.lostitem.domain.LostItem;
 import com.greedy.zupzup.lostitem.domain.LostItemStatus;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.ApproveLostItemsRequest;
 import com.greedy.zupzup.admin.lostitem.presentation.dto.RejectLostItemsRequest;
+import com.greedy.zupzup.lostitem.presentation.dto.ItemFeatureRequest;
+import com.greedy.zupzup.lostitem.repository.LostItemRepository;
 import com.greedy.zupzup.member.domain.Member;
+import com.greedy.zupzup.member.repository.MemberRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -18,6 +26,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import jakarta.servlet.http.Cookie;
 
 class AdminLostItemControllerTest extends ControllerTest {
 
@@ -25,6 +38,21 @@ class AdminLostItemControllerTest extends ControllerTest {
     private Member adminMember;
     private String adminToken;
     private Category category;
+
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private LostItemRepository lostItemRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Cookie adminCookie;
+    private Long lostItemId;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUpAdmin() {
@@ -193,6 +221,54 @@ class AdminLostItemControllerTest extends ControllerTest {
                 List<String> quizQuestions = extract.jsonPath()
                         .getList("items.find{it.id == " + i1.getId() + "}.featureOptions.quizQuestion");
                 softly.assertThat(quizQuestions).contains("어떤 브랜드의 제품인가요?", "제품의 색상은 무엇인가요?");
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("관리자 분실물 수정 API")
+    class AdminUpdateApi {
+
+        @Test
+        void 분실물_정보와_이미지를_수정하고_200_OK를_반환한다() throws Exception {
+            // given
+            LostItem item = givenPendingLostItemWithFeatures(category);
+            givenLostItemImages(item.getId(), List.of("img1", "img2"));
+
+            List<ItemFeatureRequest> featureOptions = List.of(
+                    new ItemFeatureRequest(1L, 1L),
+                    new ItemFeatureRequest(2L, 5L)
+            );
+
+            List<Long> keepImageIds = List.of(
+                    lostItemImageRepository.findByLostItemId(item.getId()).get(0).getId()
+            );
+
+            UpdateLostItemRequest updateRequest = new UpdateLostItemRequest(
+                    "수정된 설명",
+                    "학생회관",
+                    1L,
+                    "1층",
+                    category.getId(),
+                    featureOptions
+            );
+
+            // when
+            ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                    .cookie(ACCESS_TOKEN_NAME, adminToken)
+                    .contentType("multipart/form-data")
+                    .multiPart("keepImageIds", objectMapper.writeValueAsString(keepImageIds), "application/json")
+                    .multiPart("updateRequest", objectMapper.writeValueAsString(updateRequest), "application/json")
+                    .when()
+                    .put("/api/admin/lost-items/" + item.getId())
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
+                LostItem updated = lostItemRepository.findById(item.getId()).orElseThrow();
+                softly.assertThat(updated.getStatus()).isEqualTo(LostItemStatus.REGISTERED);
             });
         }
     }

--- a/src/test/java/com/greedy/zupzup/common/ControllerTest.java
+++ b/src/test/java/com/greedy/zupzup/common/ControllerTest.java
@@ -27,6 +27,7 @@ import io.restassured.RestAssured;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.cache.CacheManager;
@@ -45,6 +46,7 @@ import static com.greedy.zupzup.common.fixture.SchoolAreaFixture.*;
 @Sql("/truncate.sql")
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
 public abstract class ControllerTest {
 
     @MockitoBean

--- a/src/test/java/com/greedy/zupzup/common/ServiceUnitTest.java
+++ b/src/test/java/com/greedy/zupzup/common/ServiceUnitTest.java
@@ -1,9 +1,11 @@
 package com.greedy.zupzup.common;
 
+import com.greedy.zupzup.admin.lostitem.repository.AdminLostItemRepository;
 import com.greedy.zupzup.category.repository.CategoryRepository;
 import com.greedy.zupzup.category.repository.FeatureOptionRepository;
 import com.greedy.zupzup.global.infrastructure.S3FileCleanupService;
 import com.greedy.zupzup.global.infrastructure.S3ImageFileManager;
+import com.greedy.zupzup.lostitem.application.LostItemStorageService;
 import com.greedy.zupzup.lostitem.repository.LostItemFeatureRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemImageRepository;
 import com.greedy.zupzup.lostitem.repository.LostItemRepository;
@@ -59,6 +61,12 @@ public abstract class ServiceUnitTest {
 
     @Mock
     protected EmptyQuizGenerationStrategy emptyQuizGenerationStrategy;
+
+    @Mock
+    protected AdminLostItemRepository adminLostItemRepository;
+
+    @Mock
+    protected LostItemStorageService lostItemStorageService;
 
     protected static void setId(Object target, Long id) {
         ReflectionTestUtils.setField(target, "id", id);

--- a/src/test/java/com/greedy/zupzup/lostitem/application/LostItemRegisterServiceTest.java
+++ b/src/test/java/com/greedy/zupzup/lostitem/application/LostItemRegisterServiceTest.java
@@ -31,9 +31,6 @@ class LostItemRegisterServiceTest extends ServiceUnitTest {
     @InjectMocks
     private LostItemRegisterService lostItemRegisterService;
 
-    @Mock
-    private LostItemStorageService lostItemStorageService;
-
     private CreateLostItemCommand createDummyCommand() {
         List<MultipartFile> images = createDummyImages(3);
         List<CreateImageCommand> imageCommands = images.stream()


### PR DESCRIPTION
## 📎 Issue 번호
closed #125

## ✨ 작업 내용
PUT /api/admin/lost-items/{id}
관리자가 보류 상태인 분실물의 상세 정보를 수정하고 승인되는 api
keepImageIds에 포함되지 않은 기존 이미지는 DB와 S3에서 삭제되고 추가된 파일은 S3에 저장됩니다


## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  
놓친 부분이나 개선하면  좋을 점 피드백해주시면 감사하겠습니다!!
## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->

## ✅ 테스트
- [X] 수동 테스트 완료
- [X] 테스트 코드 완료
